### PR TITLE
test(appium): update ui locators to use xpath instead of ios

### DIFF
--- a/tests/screenobjects/CreatePinScreen.ts
+++ b/tests/screenobjects/CreatePinScreen.ts
@@ -19,9 +19,7 @@ class CreatePinScreen extends UplinkMainScreen {
   }
 
   get inputError() {
-    return $(SELECTORS.INPUT_ERROR).$(
-      "-ios class chain:**/XCUIElementTypeStaticText"
-    );
+    return $("//*[@label='input-error']/*[1]");
   }
 
   get pinInput() {
@@ -33,15 +31,11 @@ class CreatePinScreen extends UplinkMainScreen {
   }
 
   get unlockWarningParagraph() {
-    return $(SELECTORS.UNLOCK_WARNING_PARAGRAPH).$(
-      "-ios class chain:**/XCUIElementTypeStaticText"
-    );
+    return $("//*[@label='unlock-warning-paragraph']/*[1]");
   }
 
   get unlockWarningSpan() {
-    return $(SELECTORS.UNLOCK_WARNING_SPAN).$(
-      "-ios class chain:**/XCUIElementTypeStaticText"
-    );
+    return $("//*[@label='unlock-warning-span']/*[1]");
   }
 
   async enterPin(pin: string) {

--- a/tests/screenobjects/CreateUserScreen.ts
+++ b/tests/screenobjects/CreateUserScreen.ts
@@ -17,9 +17,7 @@ class CreatePinScreen extends UplinkMainScreen {
   }
 
   get inputError() {
-    return $(SELECTORS.INPUT_ERROR).$(
-      "-ios class chain:**/XCUIElementTypeStaticText"
-    );
+    return $("//*[@label='input-error']/*[1]");
   }
 
   get unlockLayout() {

--- a/tests/screenobjects/FilesScreen.ts
+++ b/tests/screenobjects/FilesScreen.ts
@@ -28,9 +28,7 @@ class FilesScreen extends UplinkMainScreen {
   }
 
   get crumbText() {
-    return $(SELECTORS.CRUMB).$(
-      "-ios class chain:**/XCUIElementTypeStaticText[1]"
-    );
+    return $("//*[@label='crumb']/*[1]/*[1]");
   }
 
   get fakeFile1() {
@@ -58,27 +56,19 @@ class FilesScreen extends UplinkMainScreen {
   }
 
   get filesInfoFreeSpaceLabel() {
-    return $(
-      'ios class chain:**/XCUIElementTypeGroup[`label == "files-info"`]/XCUIElementTypeGroup[1]/XCUIElementTypeStaticText[1]'
-    );
+    return $('//*[@label="files-info"]/*[1]/*[1]');
   }
 
   get filesInfoFreeSpaceValue() {
-    return $(
-      'ios class chain:**/XCUIElementTypeGroup[`label == "files-info"`]/XCUIElementTypeGroup[1]/XCUIElementTypeStaticText[2]'
-    );
+    return $('//*[@label="files-info"]/*[1]/*[2]');
   }
 
   get filesInfoTotalSpaceLabel() {
-    return $(
-      'ios class chain:**/XCUIElementTypeGroup[`label == "files-info"`]/XCUIElementTypeGroup[2]/XCUIElementTypeStaticText[1]'
-    );
+    return $('//*[@label="files-info"]/*[2]/*[1]');
   }
 
   get filesInfoTotalSpaceValue() {
-    return $(
-      'ios class chain:**/XCUIElementTypeGroup[`label == "files-info"`]/XCUIElementTypeGroup[2]/XCUIElementTypeStaticText[2]'
-    );
+    return $('//*[@label="files-info"]/*[2]/*[2]');
   }
 
   get filesLayout() {

--- a/tests/screenobjects/UplinkMainScreen.ts
+++ b/tests/screenobjects/UplinkMainScreen.ts
@@ -8,15 +8,13 @@ const SELECTORS = {
   FILES_BUTTON: "~files-button",
   FRIENDS_BUTTON: "~friends-button",
   PRE_RELEASE_INDICATOR: "~pre-release",
-  PRE_RELEASE_INDICATOR_TEXT:
-    '-ios class chain:**/XCUIElementTypeStaticText[`value == "Pre-release"`]',
   SETTINGS_BUTTON: "~settings-button",
   SIDEBAR: "~sidebar",
   SIDEBAR_CHILDREN: "~sidebar-children",
   SIDEBAR_SEARCH: "~sidebar-search",
   SKELETAL_USER: "~skeletal-user",
   TOAST_NOTIFICATION: "~Toast Notification",
-  WINDOW: "-ios class chain:**/XCUIElementTypeWebView",
+  WINDOW: '//*[@title="Uplink"]',
 };
 
 export default class UplinkMainScreen extends AppScreen {
@@ -53,7 +51,7 @@ export default class UplinkMainScreen extends AppScreen {
   }
 
   get prereleaseIndicatorText() {
-    return $(SELECTORS.PRE_RELEASE_INDICATOR_TEXT);
+    return $('//*[@label="pre-release"]/*[1]/*[1]');
   }
 
   get settingsButton() {
@@ -136,15 +134,7 @@ export default class UplinkMainScreen extends AppScreen {
   }
 
   async validateTextFromButtonBadge(expectedText: string) {
-    const buttonBadge = await driver.findElement(
-      "accessibility id",
-      "Button Badge"
-    );
-    const badgeText = await driver.findElementFromElement(
-      buttonBadge.ELEMENT,
-      "-ios class chain",
-      "*"
-    );
+    const badgeText = await $('//*[@label="Button Badge"]/*[1]');
     await expect($(badgeText)).toHaveTextContaining(expectedText);
   }
 }

--- a/tests/specs/03-files.spec.ts
+++ b/tests/specs/03-files.spec.ts
@@ -33,6 +33,10 @@ describe("Files Screen Tests", async () => {
 
   it("Validate Files Info is displayed in screen", async () => {
     await expect(await FilesScreen.filesInfo).toBeDisplayed();
+    await expect(await FilesScreen.filesInfoFreeSpaceLabel).toBeDisplayed();
+    await expect(await FilesScreen.filesInfoFreeSpaceValue).toBeDisplayed();
+    await expect(await FilesScreen.filesInfoTotalSpaceLabel).toBeDisplayed();
+    await expect(await FilesScreen.filesInfoTotalSpaceValue).toBeDisplayed();
   });
 
   it("Validate Files Breadcrumbs are displayed in screen", async () => {


### PR DESCRIPTION
### What this PR does 📖

- Update the few UI locators using ios class chain strategies to use xpath, so it can be detected by macos and windows
- Added test steps to validate on Files Spec to validate that Space indicator labels are displayed on screen

### Which issue(s) this PR fixes 🔨

- Resolve #

### Special notes for reviewers 🗒️

### Additional comments 🎤
