### PR TITLE
test(appium): move login steps from hook to it blocks

### DIFF
--- a/tests/specs/01-create-account.spec.ts
+++ b/tests/specs/01-create-account.spec.ts
@@ -3,12 +3,10 @@ import CreateUserScreen from "../screenobjects/CreateUserScreen";
 import WelcomeScreen from "../screenobjects/WelcomeScreen";
 
 describe("Create Account Screen Tests", async () => {
-  before(async () => {
+  it("Validate Pre Release Indicator is displayed on Screen", async () => {
     // Create an account and go to Main Screen
     await CreatePinScreen.waitForIsShown(true);
-  });
 
-  it("Validate Pre Release Indicator is displayed on Screen", async () => {
     await expect(await CreatePinScreen.prereleaseIndicator).toBeDisplayed();
     await expect(
       await CreatePinScreen.prereleaseIndicatorText

--- a/tests/specs/02-chats.spec.ts
+++ b/tests/specs/02-chats.spec.ts
@@ -3,11 +3,10 @@ import WelcomeScreen from "../screenobjects/WelcomeScreen";
 import { loginWithRandomUser } from "../helpers/commands";
 
 describe("Chats Main Screen Tests", async () => {
-  before(async () => {
-    await loginWithRandomUser();
-  });
-
   it("Validate Pre Release Indicator is displayed and has correct text", async () => {
+    //Login with random user before starting the test
+    await loginWithRandomUser();
+
     await expect(await WelcomeScreen.prereleaseIndicator).toBeDisplayed();
     await expect(
       await WelcomeScreen.prereleaseIndicatorText

--- a/tests/specs/03-files.spec.ts
+++ b/tests/specs/03-files.spec.ts
@@ -3,14 +3,14 @@ import FriendsScreen from "../screenobjects/FriendsScreen";
 import { loginWithRandomUser, showMainMenu } from "../helpers/commands";
 
 describe("Files Screen Tests", async () => {
-  before(async () => {
+  it("Validate Pre Release Indicator is displayed and has correct text", async () => {
+    // Login with a random user, show main menu and go to Files Screen
     await loginWithRandomUser();
     await showMainMenu();
     await FriendsScreen.goToFiles();
     await FilesScreen.waitForIsShown(true);
-  });
 
-  it("Validate Pre Release Indicator is displayed and has correct text", async () => {
+    // Validate Pre Release Indicator
     await expect(await FilesScreen.prereleaseIndicator).toBeDisplayed();
     await expect(
       await FilesScreen.prereleaseIndicatorText

--- a/tests/specs/04-friends.spec.ts
+++ b/tests/specs/04-friends.spec.ts
@@ -3,14 +3,14 @@ import FriendsScreen from "../screenobjects/FriendsScreen";
 import { loginWithRandomUser, showMainMenu } from "../helpers/commands";
 
 describe("Friends Screen Tests", async () => {
-  before(async () => {
+  it("Validate Pre Release Indicator is displayed and has correct text", async () => {
+    // Login with a random user, show main menu and go to Friends Screen
     await loginWithRandomUser();
     await showMainMenu();
     await FriendsScreen.goToFriends();
     await FriendsScreen.waitForIsShown(true);
-  });
 
-  it("Validate Pre Release Indicator is displayed and has correct text", async () => {
+    // Validate Pre Release Indicator is displayed
     await expect(await FriendsScreen.prereleaseIndicator).toBeDisplayed();
     await expect(
       await FriendsScreen.prereleaseIndicatorText

--- a/tests/specs/05-settings-general.spec.ts
+++ b/tests/specs/05-settings-general.spec.ts
@@ -3,14 +3,14 @@ import SettingsGeneralScreen from "../screenobjects/SettingsGeneralScreen";
 import { loginWithRandomUser, showMainMenu } from "../helpers/commands";
 
 describe("Settings - General - Tests", async () => {
-  before(async () => {
+  it("Settings General - Validate header and description texts are correct", async () => {
+    // Login with a random user, show main menu and go to Settings Screen
     await loginWithRandomUser();
     await showMainMenu();
     await FriendsScreen.goToSettings();
     await SettingsGeneralScreen.waitForIsShown(true);
-  });
 
-  it("Settings General - Validate header and description texts are correct", async () => {
+    // Start validations
     await expect(
       await SettingsGeneralScreen.uplinkOverlayHeader
     ).toHaveTextContaining("UPLINK OVERLAY");

--- a/tests/specs/06-settings-profile.spec.ts
+++ b/tests/specs/06-settings-profile.spec.ts
@@ -4,16 +4,16 @@ import SettingsProfileScreen from "../screenobjects/SettingsProfileScreen";
 import { loginWithRandomUser, showMainMenu } from "../helpers/commands";
 
 describe("Settings - Profile - Tests", async () => {
-  before(async () => {
+  it("Validate Pre Release Indicator is displayed and has correct text", async () => {
+    // Login with a random user, show main menu, go to Settings Screen and finally select the Settings Screen to validate
     await loginWithRandomUser();
     await showMainMenu();
     await FriendsScreen.goToSettings();
     await SettingsGeneralScreen.waitForIsShown(true);
     await SettingsGeneralScreen.goToProfileSettings();
     await SettingsProfileScreen.waitForIsShown(true);
-  });
 
-  it("Validate Pre Release Indicator is displayed and has correct text", async () => {
+    // Start validations
     await expect(
       await SettingsProfileScreen.prereleaseIndicator
     ).toBeDisplayed();

--- a/tests/specs/07-settings-privacy.spec.ts
+++ b/tests/specs/07-settings-privacy.spec.ts
@@ -4,16 +4,16 @@ import SettingsPrivacyScreen from "../screenobjects/SettingsPrivacyScreen";
 import { loginWithRandomUser, showMainMenu } from "../helpers/commands";
 
 describe("Settings - Privacy - Tests", async () => {
-  before(async () => {
+  it("Settings Privacy - Validate header and description texts from settings sections", async () => {
+    // Login with a random user, show main menu, go to Settings Screen and finally select the Settings Screen to validate
     await loginWithRandomUser();
     await showMainMenu();
     await FriendsScreen.goToSettings();
     await SettingsGeneralScreen.waitForIsShown(true);
     await SettingsGeneralScreen.goToPrivacySettings();
     await SettingsPrivacyScreen.waitForIsShown(true);
-  });
 
-  it("Settings Privacy - Validate header and description texts from settings sections", async () => {
+    // Start validations
     await expect(
       await SettingsPrivacyScreen.backupPhraseHeader
     ).toHaveTextContaining("BACKUP RECOVERY PHRASE");

--- a/tests/specs/08-settings-audio.spec.ts
+++ b/tests/specs/08-settings-audio.spec.ts
@@ -4,16 +4,15 @@ import SettingsAudioScreen from "../screenobjects/SettingsAudioScreen";
 import { loginWithRandomUser, showMainMenu } from "../helpers/commands";
 
 describe("Settings - Audio - Tests", async () => {
-  before(async () => {
+  it("Settings Audio - Assert screen texts", async () => {
+    // Login with a random user, show main menu, go to Settings Screen and finally select the Settings Screen to validate
     await loginWithRandomUser();
     await showMainMenu();
     await FriendsScreen.goToSettings();
     await SettingsGeneralScreen.waitForIsShown(true);
     await SettingsGeneralScreen.goToAudioSettings();
     await SettingsAudioScreen.waitForIsShown(true);
-  });
 
-  it("Settings Audio - Assert screen texts", async () => {
     // Validate texts for Interface Sounds Settings Section
     await expect(
       await SettingsAudioScreen.interfaceSoundsHeader

--- a/tests/specs/09-settings-files.spec.ts
+++ b/tests/specs/09-settings-files.spec.ts
@@ -4,16 +4,15 @@ import SettingsFilesScreen from "../screenobjects/SettingsFilesScreen";
 import { loginWithRandomUser, showMainMenu } from "../helpers/commands";
 
 describe("Settings - Files - Tests", async () => {
-  before(async () => {
+  it("Settings Files - Assert screen texts", async () => {
+    // Login with a random user, show main menu, go to Settings Screen and finally select the Settings Screen to validate
     await loginWithRandomUser();
     await showMainMenu();
     await FriendsScreen.goToSettings();
     await SettingsGeneralScreen.waitForIsShown(true);
     await SettingsGeneralScreen.goToFilesSettings();
     await SettingsFilesScreen.waitForIsShown(true);
-  });
 
-  it("Settings Files - Assert screen texts", async () => {
     // Validate LOCAL SYNC settings section texts
     await expect(
       await SettingsFilesScreen.localSyncHeader

--- a/tests/specs/10-settings-extensions.spec.ts
+++ b/tests/specs/10-settings-extensions.spec.ts
@@ -4,16 +4,16 @@ import SettingsExtensionsScreen from "../screenobjects/SettingsExtensionsScreen"
 import { loginWithRandomUser, showMainMenu } from "../helpers/commands";
 
 describe("Settings - Extensions - Tests", async () => {
-  before(async () => {
+  it("Settings Extensions - Validate texts from Extension Placeholder", async () => {
+    // Login with a random user, show main menu, go to Settings Screen and finally select the Settings Screen to validate
     await loginWithRandomUser();
     await showMainMenu();
     await FriendsScreen.goToSettings();
     await SettingsGeneralScreen.waitForIsShown(true);
     await SettingsGeneralScreen.goToExtensionsSettings();
     await SettingsExtensionsScreen.waitForIsShown(true);
-  });
 
-  it("Settings Extensions - Validate texts from Extension Placeholder", async () => {
+    // Start validations
     await expect(
       await SettingsExtensionsScreen.extensionPlaceholderName
     ).toHaveTextContaining("Placeholder");

--- a/tests/specs/11-settings-notifications.spec.ts
+++ b/tests/specs/11-settings-notifications.spec.ts
@@ -3,8 +3,9 @@ import SettingsGeneralScreen from "../screenobjects/SettingsGeneralScreen";
 import SettingsNotificationsScreen from "../screenobjects/SettingsNotificationsScreen";
 import { loginWithRandomUser, showMainMenu } from "../helpers/commands";
 
-describe("Settings - Developer - Tests", async () => {
-  before(async () => {
+describe("Settings - Notifications - Tests", async () => {
+  it("Settings - Notifications - Go To Notifications Settings", async () => {
+    // Login with a random user, show main menu, go to Settings Screen and finally select the Settings Screen to validate
     await loginWithRandomUser();
     await showMainMenu();
     await FriendsScreen.goToSettings();

--- a/tests/specs/12-settings-developer.spec.ts
+++ b/tests/specs/12-settings-developer.spec.ts
@@ -1,23 +1,18 @@
 import FriendsScreen from "../screenobjects/FriendsScreen";
 import SettingsGeneralScreen from "../screenobjects/SettingsGeneralScreen";
 import SettingsDeveloperScreen from "../screenobjects/SettingsDeveloperScreen";
-import {
-  loginWithRandomUser,
-  maximizeWindowOnMac,
-  showMainMenu,
-} from "../helpers/commands";
+import { loginWithRandomUser, showMainMenu } from "../helpers/commands";
 
 describe("Settings - Developer - Tests", async () => {
-  before(async () => {
+  it("Settings Developer - Validate headers and descriptions from Settings Sections", async () => {
+    // Login with a random user, show main menu, go to Settings Screen and finally select the Settings Screen to validate
     await loginWithRandomUser();
     await showMainMenu();
     await FriendsScreen.goToSettings();
     await SettingsGeneralScreen.waitForIsShown(true);
     await SettingsGeneralScreen.goToDeveloperSettings();
     await SettingsDeveloperScreen.waitForIsShown(true);
-  });
 
-  it("Settings Developer - Validate headers and descriptions from Settings Sections", async () => {
     // Validate DEVELOPER MODE section
     await expect(
       await SettingsDeveloperScreen.developerModeHeader


### PR DESCRIPTION
### What this PR does 📖

- Moved in all specs the login parts to the first it block so the appium logs can show where the errors are placed in case that something fails on login. Having these steps inside the before hooks were just showing errors as connrefused instead of actually indicating what UI element cannot be located

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
