### PR TITLE
screenobject(update): returned Switch Slider locators to original value

### DIFF
--- a/tests/screenobjects/SettingsAudioScreen.ts
+++ b/tests/screenobjects/SettingsAudioScreen.ts
@@ -5,7 +5,7 @@ const SELECTORS = {
   SETTINGS_CONTROL: "~settings-control",
   SETTINGS_INFO: "~settings-info",
   SETTINGS_SECTION: "~settings-section",
-  SWITCH_SLIDER: "~switch-slider",
+  SWITCH_SLIDER: "~Switch Slider",
 };
 
 class SettingsAudioScreen extends SettingsBaseScreen {
@@ -19,7 +19,7 @@ class SettingsAudioScreen extends SettingsBaseScreen {
 
   get callTimerControllerValue() {
     return $$(SELECTORS.SETTINGS_CONTROL)[3].$(
-      '//*[@label="switch-slider"]/*[1]'
+      '//*[@label="Switch Slider"]/*[1]'
     );
   }
 
@@ -41,7 +41,7 @@ class SettingsAudioScreen extends SettingsBaseScreen {
 
   get interfaceSoundsControllerValue() {
     return $$(SELECTORS.SETTINGS_CONTROL)[0].$(
-      '//*[@label="switch-slider"]/*[1]'
+      '//*[@label="Switch Slider"]/*[1]'
     );
   }
 
@@ -63,7 +63,7 @@ class SettingsAudioScreen extends SettingsBaseScreen {
 
   get mediaSoundsControllerValue() {
     return $$(SELECTORS.SETTINGS_CONTROL)[1].$(
-      '//*[@label="switch-slider"]/*[1]'
+      '//*[@label="Switch Slider"]/*[1]'
     );
   }
 
@@ -85,7 +85,7 @@ class SettingsAudioScreen extends SettingsBaseScreen {
 
   get messageSoundsControllerValue() {
     return $$(SELECTORS.SETTINGS_CONTROL)[2].$(
-      '//*[@label="switch-slider"]/*[1]'
+      '//*[@label="Switch Slider"]/*[1]'
     );
   }
 

--- a/tests/screenobjects/SettingsDeveloperScreen.ts
+++ b/tests/screenobjects/SettingsDeveloperScreen.ts
@@ -9,7 +9,7 @@ const SELECTORS = {
   SETTINGS_DEVELOPER: "~settings-developer",
   SETTINGS_INFO: "~settings-info",
   SETTINGS_SECTION: "~settings-section",
-  SWITCH_SLIDER: "~switch-slider",
+  SWITCH_SLIDER: "~Switch Slider",
   TEST_NOTIFICATIONS_BUTTON: "~test-notifications-button",
 };
 
@@ -56,7 +56,7 @@ class SettingsDeveloperScreen extends SettingsBaseScreen {
 
   get developerModeControllerValue() {
     return $$(SELECTORS.SETTINGS_CONTROL)[0].$(
-      '//*[@label="switch-slider"]/*[1]'
+      '//*[@label="Switch Slider"]/*[1]'
     );
   }
 
@@ -110,7 +110,7 @@ class SettingsDeveloperScreen extends SettingsBaseScreen {
 
   get saveLogsControllerValue() {
     return $$(SELECTORS.SETTINGS_CONTROL)[6].$(
-      '//*[@label="switch-slider"]/*[1]'
+      '//*[@label="Switch Slider"]/*[1]'
     );
   }
 

--- a/tests/screenobjects/SettingsExtensionsScreen.ts
+++ b/tests/screenobjects/SettingsExtensionsScreen.ts
@@ -3,7 +3,7 @@ import SettingsBaseScreen from "./SettingsBaseScreen";
 const SELECTORS = {
   OPEN_EXTENSIONS_FOLDER_BUTTON: "~open-extension-folder-button",
   SETTINGS_EXTENSIONS: "~settings-extensions",
-  SWITCH_SLIDER: "~switch-slider",
+  SWITCH_SLIDER: "~Switch Slider",
 };
 
 class SettingsExtensionsScreen extends SettingsBaseScreen {
@@ -29,7 +29,7 @@ class SettingsExtensionsScreen extends SettingsBaseScreen {
 
   get extensionPlaceholderControllerValue() {
     return $(SELECTORS.SETTINGS_EXTENSIONS).$(
-      '//*[@label="switch-slider"]/*[1]'
+      '//*[@label="Switch Slider"]/*[1]'
     );
   }
 

--- a/tests/screenobjects/SettingsFilesScreen.ts
+++ b/tests/screenobjects/SettingsFilesScreen.ts
@@ -6,7 +6,7 @@ const SELECTORS = {
   SETTINGS_FILES: "~settings-files",
   SETTINGS_INFO: "~settings-info",
   SETTINGS_SECTION: "~settings-section",
-  SWITCH_SLIDER: "~switch-slider",
+  SWITCH_SLIDER: "~Switch Slider",
 };
 
 class SettingsFilesScreen extends SettingsBaseScreen {
@@ -20,7 +20,7 @@ class SettingsFilesScreen extends SettingsBaseScreen {
 
   get localSyncControllerValue() {
     return $$(SELECTORS.SETTINGS_CONTROL)[0].$(
-      '//*[@label="switch-slider]/*[1]'
+      '//*[@label="Switch Slider]/*[1]'
     );
   }
 

--- a/tests/screenobjects/SettingsGeneralScreen.ts
+++ b/tests/screenobjects/SettingsGeneralScreen.ts
@@ -8,7 +8,7 @@ const SELECTORS = {
   SETTINGS_GENERAL: "~settings-general",
   SETTINGS_INFO: "~settings-info",
   SETTINGS_SECTION: "~settings-section",
-  SWITCH_SLIDER: "~switch-slider",
+  SWITCH_SLIDER: "~Switch Slider",
 };
 
 class SettingsGeneralScreen extends SettingsBaseScreen {
@@ -78,7 +78,7 @@ class SettingsGeneralScreen extends SettingsBaseScreen {
 
   get splashScreenControllerValue() {
     return $$(SELECTORS.SETTINGS_CONTROL)[1].$(
-      '//*[@label="switch-slider"]/*[1]'
+      '//*[@label="Switch Slider"]/*[1]'
     );
   }
 
@@ -116,7 +116,7 @@ class SettingsGeneralScreen extends SettingsBaseScreen {
 
   get uplinkOverlayControllerValue() {
     return $$(SELECTORS.SETTINGS_CONTROL)[0].$(
-      '//*[@label="switch-slider"]/*[1]'
+      '//*[@label="Switch Slider"]/*[1]'
     );
   }
 

--- a/tests/screenobjects/SettingsNotificationsScreen.ts
+++ b/tests/screenobjects/SettingsNotificationsScreen.ts
@@ -5,7 +5,7 @@ const SELECTORS = {
   SETTINGS_INFO: "~settings-info",
   SETTINGS_NOTIFICATIONS: "~settings-notifications",
   SETTINGS_SECTION: "~settings-section",
-  SWITCH_SLIDER: "~switch-slider",
+  SWITCH_SLIDER: "~Switch Slider",
 };
 
 class SettingsDeveloperScreen extends SettingsBaseScreen {


### PR DESCRIPTION
### What this PR does 📖

- Returned Switch Slider UI locator to "Switch Slider"

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
