### PR TITLE
screenobject(fix): fix ui locator with missing double quote

### DIFF
--- a/tests/screenobjects/SettingsFilesScreen.ts
+++ b/tests/screenobjects/SettingsFilesScreen.ts
@@ -20,7 +20,7 @@ class SettingsFilesScreen extends SettingsBaseScreen {
 
   get localSyncControllerValue() {
     return $$(SELECTORS.SETTINGS_CONTROL)[0].$(
-      '//*[@label="Switch Slider]/*[1]'
+      '//*[@label="Switch Slider"]/*[1]'
     );
   }
 


### PR DESCRIPTION
### What this PR does 📖

- Missing double quote on one UI locator from settings files

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
