### PR TITLE
test(update): update to settings profile to include your new profile …

### DIFF
--- a/tests/screenobjects/SettingsProfileScreen.ts
+++ b/tests/screenobjects/SettingsProfileScreen.ts
@@ -10,6 +10,7 @@ const SELECTORS_COMMON = {
 
 const SELECTORS_WINDOWS = {
   ADD_PICTURE_BUTTON: '[name="add-picture-button"]',
+  DISMISS_BUTTON: "//Button",
   INPUT_ERROR: '[name="input-error"]',
   INPUT_ERROR_MESSAGE: "//Text",
   PROFILE_BANNER: '[name="profile-banner"]',
@@ -21,10 +22,14 @@ const SELECTORS_WINDOWS = {
   STATUS_LABEL: "//Text[2]/Text",
   USERNAME_INPUT: '[name="username-input"]',
   USERNAME_LABEL: "//Text[1]/Text",
+  YOUR_NEW_PROFILE_DESCRIPTION_TEXT_ONE: "//Text[2]",
+  YOUR_NEW_PROFILE_DESCRIPTION_TEXT_TWO: "//Text[3]",
+  YOUR_NEW_PROFILE_HEADER_TEXT: "//Text[1]/Text",
 };
 
 const SELECTORS_MACOS = {
   ADD_PICTURE_BUTTON: "~add-picture-button",
+  DISMISS_BUTTON: "-ios class chain:**/XCUIElementTypeButton",
   INPUT_ERROR: "~input-error",
   INPUT_ERROR_MESSAGE: "-ios class chain:**/XCUIElementTypeStaticText",
   PROFILE_BANNER: "~profile-banner",
@@ -37,6 +42,12 @@ const SELECTORS_MACOS = {
   STATUS_LABEL: "-ios class chain:**/XCUIElementTypeStaticText[2]",
   USERNAME_INPUT: "~username-input",
   USERNAME_LABEL: "-ios class chain:**/XCUIElementTypeStaticText[1]",
+  YOUR_NEW_PROFILE_DESCRIPTION_TEXT_ONE:
+    "-ios class chain:**/XCUIElementTypeGroup[2]/XCUIElementTypeStaticText",
+  YOUR_NEW_PROFILE_DESCRIPTION_TEXT_TWO:
+    "-ios class chain:**/XCUIElementTypeGroup[3]/XCUIElementTypeStaticText",
+  YOUR_NEW_PROFILE_HEADER_TEXT:
+    "-ios class chain**/XCUIElementTypeStaticText[1]",
 };
 
 currentOS === "windows"
@@ -50,6 +61,10 @@ class SettingsProfileScreen extends SettingsBaseScreen {
 
   get addPictureButton() {
     return $(SELECTORS.ADD_PICTURE_BUTTON);
+  }
+
+  get dismissButton() {
+    return $(SELECTORS.SETTINGS_PROFILE).$(SELECTORS.DISMISS_BUTTON);
   }
 
   get inputError() {
@@ -98,6 +113,28 @@ class SettingsProfileScreen extends SettingsBaseScreen {
 
   get usernameLabel() {
     return $(SELECTORS.PROFILE_CONTENT).$(SELECTORS.USERNAME_LABEL);
+  }
+
+  get yourNewProfileDescriptionTextOne() {
+    return $(SELECTORS.SETTINGS_PROFILE).$(
+      SELECTORS.YOUR_NEW_PROFILE_DESCRIPTION_TEXT_ONE
+    );
+  }
+
+  get yourNewProfileDescriptionTextTwo() {
+    return $(SELECTORS.SETTINGS_PROFILE).$(
+      SELECTORS.YOUR_NEW_PROFILE_DESCRIPTION_TEXT_TWO
+    );
+  }
+
+  get yourNewProfileHeaderText() {
+    return $(SELECTORS.SETTINGS_PROFILE).$(
+      SELECTORS.YOUR_NEW_PROFILE_HEADER_TEXT
+    );
+  }
+
+  async clickOnDismissButton() {
+    await this.dismissButton.click();
   }
 
   async deleteStatus() {

--- a/tests/screenobjects/SettingsProfileScreen.ts
+++ b/tests/screenobjects/SettingsProfileScreen.ts
@@ -47,7 +47,7 @@ const SELECTORS_MACOS = {
   YOUR_NEW_PROFILE_DESCRIPTION_TEXT_TWO:
     "-ios class chain:**/XCUIElementTypeGroup[3]/XCUIElementTypeStaticText",
   YOUR_NEW_PROFILE_HEADER_TEXT:
-    "-ios class chain**/XCUIElementTypeStaticText[1]",
+    "-ios class chain:**/XCUIElementTypeStaticText/XCUIElementTypeStaticText",
 };
 
 currentOS === "windows"

--- a/tests/specs/05-settings-general.spec.ts
+++ b/tests/specs/05-settings-general.spec.ts
@@ -1,10 +1,12 @@
 import FriendsScreen from "../screenobjects/FriendsScreen";
 import SettingsGeneralScreen from "../screenobjects/SettingsGeneralScreen";
+import SettingsProfileScreen from "../screenobjects/SettingsProfileScreen";
 
 export default async function settingsGeneral() {
   it("Settings General - Validate header and description texts are correct", async () => {
     // Go to Settings Screen
     await FriendsScreen.goToSettings();
+    await SettingsProfileScreen.goToGeneralSettings();
     await SettingsGeneralScreen.waitForIsShown(true);
 
     // Start validations

--- a/tests/specs/06-settings-profile.spec.ts
+++ b/tests/specs/06-settings-profile.spec.ts
@@ -30,6 +30,23 @@ export default async function settingsProfile() {
     await expect(await SettingsProfileScreen.sidebarSearch).toBeDisplayed();
   });
 
+  it("Settings Profile - Assert texts for Your New Profile dialog and dismiss it", async () => {
+    expect(
+      await SettingsProfileScreen.yourNewProfileHeaderText
+    ).toHaveTextContaining("YOUR NEW PROFILE!");
+    expect(
+      await SettingsProfileScreen.yourNewProfileDescriptionTextOne
+    ).toHaveTextContaining(
+      "Tell the world all about yourself, well tell them as much as you can while we're still under construction, at least."
+    );
+    expect(
+      await SettingsProfileScreen.yourNewProfileDescriptionTextTwo
+    ).toHaveTextContaining(
+      "First step, pick out a profile picture and maybe even a banner too!"
+    );
+    await SettingsProfileScreen.clickOnDismissButton();
+  });
+
   it("Settings Profile - Assert screen and placeholder texts", async () => {
     // Assert username and status labels are displayed on screen
     await expect(


### PR DESCRIPTION
### What this PR does 📖

- Updates to settings profile screenobject to add UI locators for new elements (your new profile modal)
- Updates to test spec for settings profile to include validations of texts and dismiss the same modal and then continue with the same tests

### Which issue(s) this PR fixes 🔨

- Resolve #81 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
