### PR TITLE
chore(appium): hardcode appium port on mac to default from driver 10100

### DIFF
--- a/config/wdio.shared.mac.appium.conf.ts
+++ b/config/wdio.shared.mac.appium.conf.ts
@@ -27,6 +27,6 @@ config.services = (config.services ? config.services : []).concat([
 // =====================
 //
 
-config.port = 4723;
+config.port = 10100;
 
 export default config;


### PR DESCRIPTION
### What this PR does 📖

- Hardcore config.port to 10100 on wdio.conf.shared file for MacOS, since this is the default port used by appium mac2 driver

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
