### PR TITLE
test(update): fix macos test on profile name validation

### DIFF
--- a/tests/specs/01-create-account.spec.ts
+++ b/tests/specs/01-create-account.spec.ts
@@ -1,4 +1,4 @@
-import { maximizeWindow, saveUsername } from "../helpers/commands";
+import { maximizeWindow } from "../helpers/commands";
 import CreatePinScreen from "../screenobjects/CreatePinScreen";
 import CreateUserScreen from "../screenobjects/CreateUserScreen";
 import WelcomeScreen from "../screenobjects/WelcomeScreen";
@@ -141,8 +141,7 @@ export default async function createAccount() {
   });
 
   it("Enter valid username to continue", async () => {
-    await CreateUserScreen.enterUsername("test123");
-    await CreateUserScreen.saveUsername();
+    await CreateUserScreen.enterUsername("Test123");
     expect(await CreateUserScreen.getStatusOfCreateAccountButton()).toEqual(
       "true"
     );

--- a/tests/specs/06-settings-profile.spec.ts
+++ b/tests/specs/06-settings-profile.spec.ts
@@ -1,4 +1,3 @@
-import { getCurrentUsername } from "../helpers/commands";
 import SettingsGeneralScreen from "../screenobjects/SettingsGeneralScreen";
 import SettingsProfileScreen from "../screenobjects/SettingsProfileScreen";
 
@@ -58,13 +57,10 @@ export default async function settingsProfile() {
     );
 
     // Assert username and status placeholder values are displayed
-    const currentUsername = await getCurrentUsername();
-    await expect(
-      await SettingsProfileScreen.usernameInput
-    ).toHaveTextContaining(currentUsername);
-    await expect(await SettingsProfileScreen.statusInput).toHaveTextContaining(
-      ""
+    expect(await SettingsProfileScreen.usernameInput).toHaveTextContaining(
+      "Test123"
     );
+    expect(await SettingsProfileScreen.statusInput).toHaveTextContaining("");
   });
 
   // Skipping test since items are not connected with Warp


### PR DESCRIPTION
### What this PR does 📖

- MacOS CI is converting the first letter of username into capital letter and causing failures. This happens also in my local environment, so for now I am sending a username with first letter capitalized to avoid discrepancies between mac and windows

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
