### PR TITLE
test(update): fixes for settings profile and pin username spaces tests

### DIFF
--- a/config/wdio.windows.app.conf.ts
+++ b/config/wdio.windows.app.conf.ts
@@ -25,6 +25,7 @@ config.capabilities = [
     // This is `appium:` for all Appium Capabilities which can be found here
     "appium:automationName": "windows",
     "appium:app": join(process.cwd(), "\\apps\\ui.exe"),
+    "ms:waitForAppLaunch": 30,
   },
 ];
 

--- a/config/wdio.windows.ci.conf.ts
+++ b/config/wdio.windows.ci.conf.ts
@@ -24,6 +24,7 @@ config.capabilities = [
     // This is `appium:` for all Appium Capabilities which can be found here
     "appium:automationName": "windows",
     "appium:app": join(process.cwd(), "\\apps\\ui.exe"),
+    "ms:waitForAppLaunch": 30,
   },
 ];
 

--- a/tests/screenobjects/SettingsGeneralScreen.ts
+++ b/tests/screenobjects/SettingsGeneralScreen.ts
@@ -174,7 +174,7 @@ class SettingsGeneralScreen extends SettingsBaseScreen {
         language + "\n"
       );
     } else if ((await this.getCurrentDriver()) === "windows") {
-      await $$('[name="settings-control"]')[1].addValue(language + "\n");
+      await $$('[name="settings-control"]')[1].addValue(language + "\uE007");
     }
   }
 
@@ -184,7 +184,7 @@ class SettingsGeneralScreen extends SettingsBaseScreen {
         theme + "\n"
       );
     } else if ((await this.getCurrentDriver()) === "windows") {
-      await $$('[name="settings-control"]')[0].addValue(theme + "\n");
+      await $$('[name="settings-control"]')[0].addValue(theme + "\uE007");
     }
   }
 }

--- a/tests/screenobjects/SettingsProfileScreen.ts
+++ b/tests/screenobjects/SettingsProfileScreen.ts
@@ -1,4 +1,4 @@
-import { selectFileOnMacos } from "../helpers/commands";
+import { selectFileOnMacos, selectFileOnWindows } from "../helpers/commands";
 import SettingsBaseScreen from "./SettingsBaseScreen";
 
 const currentOS = driver.capabilities.automationName;
@@ -189,36 +189,35 @@ class SettingsProfileScreen extends SettingsBaseScreen {
   }
 
   async uploadBannerPicture(relativePath: string) {
-    // Click on Profile Banner
-    await this.profileBanner.click();
-
-    // Invoke File Selection Helper Function for MacOS to select the banner image to upload. A similar method will be implemented in the future for Windows
-    if ((await this.getCurrentDriver()) === "mac2") {
+    // Invoke File Selection method depending on current OS driver
+    // If Windows driver is running, first retrieve the current context and pass it to file selection function
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === "mac2") {
+      await this.profileBanner.click();
       await selectFileOnMacos(relativePath);
-
-      // Validate that profile banner is displayed on screen
-      await expect(await this.profileBanner).toBeDisplayed();
-    } else if ((await this.getCurrentDriver()) === "windows") {
-      console.log("Not implemented yet");
+    } else if (currentDriver === "windows") {
+      const uplinkContext = await driver.getWindowHandle();
+      await this.profileBanner.click();
+      await selectFileOnWindows(relativePath, uplinkContext);
     }
+    // Validate that profile banner is displayed on screen
+    await expect(await this.profileBanner).toBeDisplayed();
   }
 
   async uploadProfilePicture(relativePath: string) {
-    // Click on Profile Picture add button
-    await await this.addPictureButton.click();
-
-    // Invoke File Selection Helper Function for MacOS to select the profile image to upload. A similar method will be implemented in the future for Windows
-    if ((await this.getCurrentDriver()) === "mac2") {
+    // Invoke File Selection method depending on current OS driver
+    // If Windows driver is running, first retrieve the current context and pass it to file selection function
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === "mac2") {
+      await this.profilePicture.click();
       await selectFileOnMacos(relativePath);
-
-      // Click on username input to move the mouse cursor
-      await this.usernameInput.click();
-
-      // Validate that profile picture is displayed on screen
-      await expect(await this.profilePicture).toBeDisplayed();
-    } else if ((await this.getCurrentDriver()) === "windows") {
-      console.log("Not implemented yet");
+    } else if (currentDriver === "windows") {
+      const uplinkContext = await driver.getWindowHandle();
+      await this.profilePicture.click();
+      await selectFileOnWindows(relativePath, uplinkContext);
     }
+    // Validate that profile banner is displayed on screen
+    await expect(await this.profilePicture).toBeDisplayed();
   }
 }
 

--- a/tests/specs/01-create-account.spec.ts
+++ b/tests/specs/01-create-account.spec.ts
@@ -57,11 +57,10 @@ export default async function createAccount() {
     await (await CreatePinScreen.pinInput).clearValue();
   });
 
-  // Test is failing because webdriverio handles spaces as dots and needs more research to avoid flakiness
-  xit("Enter a pin with spaces", async () => {
+  it("Enter a pin with spaces", async () => {
     // Enter pin value with spaces
-    const emptySpaces = "    ";
-    await CreatePinScreen.pinInput.addValue(`123${emptySpaces}`);
+    await (await CreatePinScreen.pinInput).click();
+    await CreatePinScreen.enterPin("1234" + "             ");
     await expect(await CreatePinScreen.inputError).toBeDisplayed();
     await expect(await CreatePinScreen.inputErrorText).toHaveTextContaining(
       "Spaces are not allowed."
@@ -115,11 +114,10 @@ export default async function createAccount() {
     );
   });
 
-  // Test is failing because webdriverio handles spaces as dots and needs more research to avoid flakiness
-  xit("Username with spaces and attempt to continue", async () => {
+  it("Username with spaces and attempt to continue", async () => {
     // Enter pin value with spaces
-    const emptySpaces = "    ";
-    await CreateUserScreen.usernameInput.addValue(`123${emptySpaces}`);
+    await (await CreateUserScreen.usernameInput).click();
+    await CreateUserScreen.enterUsername("1234" + "             ");
     expect(await CreateUserScreen.getStatusOfCreateAccountButton()).toEqual(
       "false"
     );

--- a/tests/specs/04-friends.spec.ts
+++ b/tests/specs/04-friends.spec.ts
@@ -52,12 +52,6 @@ export default async function friends() {
     await FriendsScreen.toastNotification.waitForDisplayed({ reverse: true });
   });
 
-  // Skipped since it needs to be implemented
-  xit("User Input Error Message is displayed when input is less than 56 characters", async () => {});
-
-  // Skipped since it needs to be implemented
-  xit("Add a friend", async () => {});
-
   it("Switch to Pending Friends view and validate elements displayed", async () => {
     await FriendsScreen.goToPendingFriendsList();
     await expect(await FriendsScreen.incomingRequestsList).toBeDisplayed();

--- a/tests/specs/05-settings-profile.spec.ts
+++ b/tests/specs/05-settings-profile.spec.ts
@@ -30,7 +30,7 @@ export default async function settingsProfile() {
     await expect(await SettingsProfileScreen.sidebarSearch).toBeDisplayed();
   });
 
-  // It is not present in screen now
+  // It is not present in screen now on MacOS builds
   xit("Settings Profile - Assert texts for Your New Profile dialog and dismiss it", async () => {
     expect(
       await SettingsProfileScreen.yourNewProfileHeaderText
@@ -64,9 +64,8 @@ export default async function settingsProfile() {
     expect(await SettingsProfileScreen.statusInput).toHaveTextContaining("");
   });
 
-  // Skipping test since items are not connected with Warp
   // Needs visual validation steps to ensure that picture was actually loaded matches with expected image
-  xit("Settings Profile - Add profile picture", async () => {
+  it("Settings Profile - Add profile picture", async () => {
     await SettingsProfileScreen.uploadProfilePicture(
       "./tests/fixtures/logo.jpg"
     );
@@ -84,26 +83,23 @@ export default async function settingsProfile() {
     ).toHaveTextContaining("Change banner");
   });
 
-  // Skipping test since items are not connected with Warp
   // Needs visual validation steps to ensure that picture was actually loaded matches with expected image
-  xit("Settings Profile - Add banner picture", async () => {
+  it("Settings Profile - Add banner picture", async () => {
     await SettingsProfileScreen.uploadBannerPicture(
       "./tests/fixtures/banner.jpg"
     );
     await (await SettingsProfileScreen.usernameInput).click();
   });
 
-  // Skipping test since items are not connected with Warp
   // Needs visual validation steps to ensure that picture was actually loaded matches with expected image
-  xit("Settings Profile - Change profile picture", async () => {
+  it("Settings Profile - Change profile picture", async () => {
     await SettingsProfileScreen.uploadProfilePicture(
       "./tests/fixtures/second-profile.png"
     );
   });
 
-  // Skipping test since items are not connected with Warp
   // Needs visual validation steps to ensure that picture was actually loaded matches with expected image
-  xit("Settings Profile - Change banner picture", async () => {
+  it("Settings Profile - Change banner picture", async () => {
     await SettingsProfileScreen.uploadBannerPicture(
       "./tests/fixtures/second-banner.jpg"
     );
@@ -139,16 +135,14 @@ export default async function settingsProfile() {
     await SettingsProfileScreen.enterUsername("1234");
   });
 
-  // Test is failing because webdriverio handles spaces as dots and needs more research to avoid flakiness
-  xit("Settings Profile - Spaces are not allowed", async () => {
+  it("Settings Profile - Spaces are not allowed", async () => {
     // Enter username value with spaces
-    await SettingsProfileScreen.enterUsername("1234     ").then(() => {
-      // Validate that error message is displayed
-      expect(SettingsProfileScreen.inputError).toBeDisplayed();
-      expect(SettingsProfileScreen.inputErrorMessage).toHaveTextContaining(
-        "Spaces are not allowed."
-      );
-    });
+    await SettingsProfileScreen.enterUsername("1234" + "             ");
+    // Validate that error message is displayed
+    await expect(await SettingsProfileScreen.inputError).toBeDisplayed();
+    await expect(
+      await SettingsProfileScreen.inputErrorMessage
+    ).toHaveTextContaining("Spaces are not allowed.");
 
     // Clear value from username input, then enter a valid value again
     await SettingsProfileScreen.enterUsername("1234");
@@ -183,7 +177,4 @@ export default async function settingsProfile() {
     // Clear value from username input, then enter a valid value again
     await SettingsProfileScreen.enterUsername("1234");
   });
-
-  // Skipped since we need to implement visual testing to test this button since element is not part of the DOM structure on Appium
-  xit("Settings Profile - Status delete button", async () => {});
 }


### PR DESCRIPTION
### What this PR does 📖

- Implemented add/change profile/banner picture tests for Windows and now unskipped the tests to work on MacOS as well
- Updated screenobject file of Settings Profile to add functions to upload banners and profile pictures
- Fixed tests related to username, pin inputs not allowing spaces
- Removed tests that do not contain any steps on Friends spec

### Which issue(s) this PR fixes 🔨

- Resolve #50 and #105 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
