### PR TITLE
test(update): fix friends and context menu tests for windows

### DIFF
--- a/config/wdio.windows.ci.conf.ts
+++ b/config/wdio.windows.ci.conf.ts
@@ -7,7 +7,7 @@ const mkdirp = require("mkdirp");
 // ============
 // Specs
 // ============
-config.specs = [join(process.cwd(), "./tests/suites/01-UplinkTestSuite.ts")];
+config.specs = [join(process.cwd(), "./tests/suites/*.ts")];
 
 // ============
 // Capabilities

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@wdio/spec-reporter": "^8.3.0",
     "eslint-plugin-wdio": "^7.19.4",
     "prettier": "2.8.3",
+    "robotjs": "^0.6.0",
     "ts-node": "^10.8.0",
     "typescript": "^4.6.4",
     "webdriverio": "^8.2.4"

--- a/tests/helpers/commands.ts
+++ b/tests/helpers/commands.ts
@@ -134,6 +134,12 @@ export async function loginWithTestUser() {
 
   // Ensure Main Screen is displayed
   await WelcomeScreen.waitForIsShown(true);
+
+  // Only maximize if current driver is windows
+  const currentDriver = await WelcomeScreen.getCurrentDriver();
+  if (currentDriver === "windows") {
+    await maximizeWindow();
+  }
 }
 
 export async function launchApplication() {

--- a/tests/helpers/commands.ts
+++ b/tests/helpers/commands.ts
@@ -2,13 +2,13 @@ import CreatePinScreen from "../screenobjects/CreatePinScreen";
 import CreateUserScreen from "../screenobjects/CreateUserScreen";
 import FriendsScreen from "../screenobjects/FriendsScreen";
 import WelcomeScreen from "../screenobjects/WelcomeScreen";
-import UplinkMainScreen from "../screenobjects/UplinkMainScreen";
 import { faker } from "@faker-js/faker";
 import { homedir } from "os";
 import { join } from "path";
 const { readFileSync, rmSync, writeFileSync } = require("fs");
 const fsp = require("fs").promises;
 const mkdirp = require("mkdirp");
+const robot = require("robotjs");
 
 // Users cache helper functions
 
@@ -156,7 +156,11 @@ export async function launchApplication() {
 export async function closeApplication() {
   const currentOS = await driver.capabilities.automationName;
   if (currentOS === "windows") {
-    await $('[name="close-button"]').click();
+    await driver.executeScript("windows: closeApp", [
+      {
+        app: join(process.cwd(), "\\apps\\ui.exe"),
+      },
+    ]);
   } else if (currentOS === "mac2") {
     await $("~_XCUI:CloseWindow").click();
   }
@@ -267,7 +271,20 @@ export async function selectFileOnMacos(relativePath: string) {
   await $("~open-panel").waitForExist({ reverse: true });
 }
 
+export async function rightClickOnMacOS(locator: WebdriverIO.Element) {
+  await driver.executeScript("macos: rightClick", [
+    {
+      elementId: locator,
+    },
+  ]);
+}
+
 // Windows driver helper functions
+
+export async function rightClickOnWindows(locator: WebdriverIO.Element) {
+  await driver.touchAction([{ action: "press", element: locator }]);
+  robot.mouseClick("right");
+}
 
 export async function selectFileOnWindows(
   relativePath: string,

--- a/tests/screenobjects/FriendsScreen.ts
+++ b/tests/screenobjects/FriendsScreen.ts
@@ -1,4 +1,4 @@
-import { Key } from "webdriverio";
+import { rightClickOnMacOS, rightClickOnWindows } from "../helpers/commands";
 import UplinkMainScreen from "./UplinkMainScreen";
 
 const currentOS = driver.capabilities.automationName;
@@ -324,6 +324,7 @@ class FriendsScreen extends UplinkMainScreen {
   }
 
   async getAllFriendsList() {
+    await browser.pause(1000);
     const friends = await $(SELECTORS.FRIENDS_LIST).$$(SELECTORS.FRIEND_INFO);
     let results = [];
     for (let friend of friends) {
@@ -333,6 +334,7 @@ class FriendsScreen extends UplinkMainScreen {
   }
 
   async getBlockedList() {
+    await browser.pause(1000);
     const friends = await $(SELECTORS.BLOCKED_LIST).$$(SELECTORS.FRIEND_INFO);
     let results = [];
     for (let friend of friends) {
@@ -342,6 +344,7 @@ class FriendsScreen extends UplinkMainScreen {
   }
 
   async getFriendRecordByName(name: string) {
+    await browser.pause(1000);
     const friends = await this.friendRecords;
     for (let friend of friends) {
       if (
@@ -356,6 +359,7 @@ class FriendsScreen extends UplinkMainScreen {
   }
 
   async getIncomingList() {
+    await browser.pause(1000);
     const friends = await $(SELECTORS.INCOMING_REQUESTS_LIST).$$(
       SELECTORS.FRIEND_INFO
     );
@@ -367,6 +371,7 @@ class FriendsScreen extends UplinkMainScreen {
   }
 
   async getOutgoingList() {
+    await browser.pause(1000);
     const friends = await $(SELECTORS.OUTGOING_REQUESTS_LIST).$$(
       SELECTORS.FRIEND_INFO
     );
@@ -437,19 +442,11 @@ class FriendsScreen extends UplinkMainScreen {
   async openFriendContextMenu(name: string) {
     const friendToClick = await this.getFriendRecordByName(name);
     const currentDriver = await this.getCurrentDriver();
+    const friendBubble = await friendToClick.$(SELECTORS.FRIEND_USER_IMAGE);
     if (currentDriver === "mac2") {
-      const friendBubble = await friendToClick.$(SELECTORS.FRIEND_USER_IMAGE);
-      await driver.executeScript("macos: rightClick", [
-        {
-          elementId: friendBubble,
-        },
-      ]);
+      await rightClickOnMacOS(friendBubble);
     } else if (currentDriver === "windows") {
-      const friendName = await friendToClick.$(SELECTORS.FRIEND_INFO_USERNAME);
-      await friendName.click();
-      await browser.pause(100);
-      await friendName.click();
-      await driver.keys([Key.Shift, "F10"]);
+      await rightClickOnWindows(friendBubble);
     }
     await (await this.contextMenu).waitForDisplayed();
   }

--- a/tests/specs/04-friends.spec.ts
+++ b/tests/specs/04-friends.spec.ts
@@ -39,7 +39,9 @@ export default async function friends() {
 
   it("User can type on user search input bar", async () => {
     await FriendsScreen.enterFriendDidKey("Hello");
-    expect(await FriendsScreen.addSomeoneInput).toHaveTextContaining("Hello");
+    await expect(await FriendsScreen.addSomeoneInput).toHaveTextContaining(
+      "Hello"
+    );
     await FriendsScreen.deleteAddFriendInput();
   });
 
@@ -216,8 +218,8 @@ export default async function friends() {
     const favoritedUser = await FriendsScreen.getAbbreviatedFavUser(friendName);
     const currentFavorites = await FriendsScreen.getUsersFromFavorites();
     const favoriteBubble = await FriendsScreen.favoritesUserImage;
-    expect(currentFavorites.includes(favoritedUser)).toEqual(true);
-    expect(favoriteBubble).toBeDisplayed();
+    await expect(currentFavorites.includes(favoritedUser)).toEqual(true);
+    await expect(favoriteBubble).toBeDisplayed();
   });
 
   it("Context Menu - Remove Friend", async () => {


### PR DESCRIPTION
### What this PR does 📖

- Changed CI config file for Windows to execute the Friends Reusable accounts test
- Fixed issue on Windows that was launching two instances of Uplink instead of just one when doing a reset
- Added helper functions to execute right click for Windows and move the one from MacOS previously created into helper functions file
- Ensured that friends reusable accounts test are working on both platforms now

### Which issue(s) this PR fixes 🔨

- Resolve #83 and #84 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
