### PR TITLE
test(add): add context menu tests for files and folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ appium.log
 test-report/
 test-results/
 tests/fixtures/users/
+tests/fixtures/newname.jpg
+

--- a/tests/helpers/commands.ts
+++ b/tests/helpers/commands.ts
@@ -318,7 +318,6 @@ export async function saveFileOnWindows(
   const filepath = join(process.cwd(), "\\tests\\fixtures\\", filename);
 
   // Pause for one second until explorer window is displayed and switch to it
-  await maximizeWindow();
   const windows = await driver.getWindowHandles();
   let explorerWindow;
   if (windows[0] === uplinkContext) {
@@ -337,11 +336,14 @@ export async function saveFileOnWindows(
   await (
     await $("/Window/Pane[1]/ComboBox[1]/Edit")
   ).setValue(filename + "\uE007");
+
+  // Wait for Save Panel not to be displayed
+  await $("~TitleBar").waitForDisplayed({ reverse: true });
+
   await driver.switchToWindow(uplinkContext);
-  await maximizeWindow();
 
   // Delete file from local files
-  rmSync(filepath, { force: true });
+  await rmSync(filepath, { force: true });
   return;
 }
 

--- a/tests/helpers/commands.ts
+++ b/tests/helpers/commands.ts
@@ -241,6 +241,24 @@ export async function clickOnSwitchMacOS(element: WebdriverIO.Element) {
   return;
 }
 
+export async function saveFileOnMacOS(filename: string) {
+  // Wait for Save Dialog to be displayed
+  await $("~save-panel").waitForDisplayed();
+
+  // Type the new file name
+  await (await $("~saveAsNameTextField")).setValue(filename);
+
+  // Click on OK Button to save into Downloads folder
+  await $("~OKButton").click();
+
+  // Wait until Save Dialog is closed
+  await $("~save-panel").waitForExist({ reverse: true });
+
+  // Delete file from local files
+  const target = join(process.cwd(), "/tests/fixtures/", filename);
+  rmSync(target, { force: true });
+}
+
 export async function selectFileOnMacos(relativePath: string) {
   // Get the filepath to select on browser
   const filepath = join(process.cwd(), relativePath);
@@ -290,6 +308,41 @@ export async function rightClickOnMacOS(locator: WebdriverIO.Element) {
 export async function rightClickOnWindows(locator: WebdriverIO.Element) {
   await driver.touchAction([{ action: "press", element: locator }]);
   robot.mouseClick("right");
+}
+
+export async function saveFileOnWindows(
+  filename: string,
+  uplinkContext: string
+) {
+  // Get the filepath to select on browser
+  const filepath = join(process.cwd(), "\\tests\\fixtures\\", filename);
+
+  // Pause for one second until explorer window is displayed and switch to it
+  await maximizeWindow();
+  const windows = await driver.getWindowHandles();
+  let explorerWindow;
+  if (windows[0] === uplinkContext) {
+    explorerWindow = windows[1];
+  } else {
+    explorerWindow = windows[0];
+  }
+
+  await driver.switchToWindow(explorerWindow);
+
+  // Wait for Save Panel to be displayed
+  await $("~TitleBar").waitForDisplayed();
+
+  // Type file location and hit enter
+  await $("/Window/Pane[1]/ComboBox[1]/Edit").clearValue();
+  await (
+    await $("/Window/Pane[1]/ComboBox[1]/Edit")
+  ).setValue(filename + "\uE007");
+  await driver.switchToWindow(uplinkContext);
+  await maximizeWindow();
+
+  // Delete file from local files
+  rmSync(filepath, { force: true });
+  return;
 }
 
 export async function selectFileOnWindows(

--- a/tests/screenobjects/FilesScreen.ts
+++ b/tests/screenobjects/FilesScreen.ts
@@ -19,6 +19,7 @@ const SELECTORS_WINDOWS = {
   CONTEXT_MENU_OPTION: '[name="Context Item"]',
   CRUMB: '[name="crumb"]',
   CRUMB_TEXT: "//Text",
+  FILE_FOLDER_NAME_TEXT: "//Text/Text",
   FILES_BODY: '[name="files-body"]',
   FILES_BREADCRUMBS: '[name="files-breadcrumbs"]',
   FILES_INFO: '[name="files-info"]',
@@ -48,6 +49,8 @@ const SELECTORS_MACOS = {
     "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText[1]",
   FILE_FOLDER_NAME:
     "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText/XCUIElementTypeStaticText",
+  FILE_FOLDER_NAME_TEXT:
+    "-ios class chain:**/XCUIElementTypeStaticText/XCUIElementTypeStaticText",
   FILES_BODY: "~files-body",
   FILES_BREADCRUMBS: "~files-breadcrumbs",
   FILES_INFO: "~files-info",
@@ -112,6 +115,10 @@ class FilesScreen extends UplinkMainScreen {
 
   get crumbText() {
     return $$(SELECTORS.CRUMB).$(SELECTORS.CRUMB_TEXT);
+  }
+
+  get fileFolderNameText() {
+    return $(SELECTORS.FILE_FOLDER_NAME_TEXT);
   }
 
   get filesBody() {
@@ -288,12 +295,15 @@ class FilesScreen extends UplinkMainScreen {
   }
 
   async openFilesContextMenu(name: string) {
-    const elementToRightClick = await this.getLocatorOfFolderFile(name);
+    const elementLocator = await this.getLocatorOfFolderFile(name);
+    const fileFolderToRightClick = await elementLocator?.$(
+      SELECTORS.FILE_FOLDER_NAME_TEXT
+    );
     const currentDriver = await this.getCurrentDriver();
     if (currentDriver === "mac2") {
-      await rightClickOnMacOS(elementToRightClick);
+      await rightClickOnMacOS(fileFolderToRightClick);
     } else if (currentDriver === "windows") {
-      await rightClickOnWindows(elementToRightClick);
+      await rightClickOnWindows(fileFolderToRightClick);
     }
     await (await this.contextMenu).waitForDisplayed();
   }

--- a/tests/specs/03-files.spec.ts
+++ b/tests/specs/03-files.spec.ts
@@ -130,14 +130,15 @@ export default async function files() {
     expect(renamedFile).toExist();
   });
 
-  it("Context Menu - File - Download", async () => {
-    // Open context menu for renamed.jpg and select the second option "Download"
+  // Needs research on how to implement on Windows
+  xit("Context Menu - File - Download", async () => {
+    // Open context menu for newname.jpg and select the second option "Download"
     await FilesScreen.openFilesContextMenu("newname.jpg");
     await FilesScreen.downloadFile("saved.jpg");
   });
 
   it("Context Menu - File - Delete", async () => {
-    // Open context menu for renamed.jpg file and select the second option "Delete"
+    // Open context menu for newname.jpg file and select the second option "Delete"
     await FilesScreen.openFilesContextMenu("newname.jpg");
     await FilesScreen.contextMenuOption[2].click();
 

--- a/tests/specs/03-files.spec.ts
+++ b/tests/specs/03-files.spec.ts
@@ -98,4 +98,53 @@ export default async function files() {
     const newFile = await FilesScreen.getLocatorOfFolderFile("logo.jpg");
     expect(newFile).toExist();
   });
+
+  it("Context Menu - Folder - Rename", async () => {
+    // Open context menu for testfolder01 and select the first option "Rename"
+    await FilesScreen.openFilesContextMenu("testfolder01");
+    await FilesScreen.contextMenuOption[0].click();
+
+    // Set the new name for the folder
+    const renamedFolder = await FilesScreen.updateNameFileFolder("newname");
+    expect(renamedFolder).toExist();
+  });
+
+  it("Context Menu - Folder - Delete", async () => {
+    // Open context menu for newname folder and select the second option "Delete"
+    await FilesScreen.openFilesContextMenu("newname");
+    await FilesScreen.contextMenuOption[1].click();
+
+    // Ensure that folder deleted does not exist anymore
+    const nonExistingFolderLocator =
+      await FilesScreen.getLocatorOfDeletedElement("newname");
+    expect(await $(nonExistingFolderLocator)).not.toExist();
+  });
+
+  it("Context Menu - File - Rename", async () => {
+    // Open context menu for logo.jpg file and select the first option "Rename"
+    await FilesScreen.openFilesContextMenu("logo.jpg");
+    await FilesScreen.contextMenuOption[0].click();
+
+    // Set the new name for the file
+    const renamedFile = await FilesScreen.updateNameFileFolder("newname");
+    expect(renamedFile).toExist();
+  });
+
+  it("Context Menu - File - Download", async () => {
+    // Open context menu for renamed.jpg and select the second option "Download"
+    await FilesScreen.openFilesContextMenu("newname.jpg");
+    await FilesScreen.downloadFile("saved.jpg");
+  });
+
+  it("Context Menu - File - Delete", async () => {
+    // Open context menu for renamed.jpg file and select the second option "Delete"
+    await FilesScreen.openFilesContextMenu("newname.jpg");
+    await FilesScreen.contextMenuOption[2].click();
+
+    // Ensure that file deleted does not exist anymore
+    const nonExistingFile = await FilesScreen.getLocatorOfDeletedElement(
+      "newname.jpg"
+    );
+    expect(await $(nonExistingFile)).not.toExist();
+  });
 }


### PR DESCRIPTION
### What this PR does 📖

- Adding context menu tests for files and folders
- Added screenobject UI locators and methods to handle rename and download functions
- Added helper functions to handle native Save Dialogs from MacOS and Windows

### Which issue(s) this PR fixes 🔨

- Resolve #62 and #63 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
