### PR TITLE
chore(appium): modify build cron job to run every 6 hours

### DIFF
--- a/.github/workflows/build-cron-job.yml
+++ b/.github/workflows/build-cron-job.yml
@@ -2,7 +2,7 @@ name: Build App Windows and MacOS 🧪
 
 on:
   schedule:
-    - cron: "20 0/1 * * 1-5"
+    - cron: "0 0/6 * * 1-5"
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -105,6 +105,8 @@ jobs:
     steps:
       - name: Checkout testing directory 🔖
         uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT }}
 
       - name: Delete contents from apps folder 🧹
         run: rm -rf ./apps


### PR DESCRIPTION
### What this PR does 📖

- Updated cron job to run every 6 hours
- Added PAT so the job can push to dev branch the files

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
