### PR TITLE
test(add): chat messages contents

### DIFF
--- a/tests/helpers/commands.ts
+++ b/tests/helpers/commands.ts
@@ -350,9 +350,7 @@ export async function saveFileOnWindows(
   return;
 }
 
-export async function selectFileOnWindows(
-  relativePath: string,
-) {
+export async function selectFileOnWindows(relativePath: string) {
   // Get the filepath to select on browser
   const filepath = join(process.cwd(), relativePath);
 

--- a/tests/screenobjects/ChatScreen.ts
+++ b/tests/screenobjects/ChatScreen.ts
@@ -82,7 +82,7 @@ class ChatScreen extends UplinkMainScreen {
   }
 
   get chatMessage() {
-    return $$(SELECTORS.MESSAGE_GROUP).$$(SELECTORS.CHAT_MESSAGE);
+    return $(SELECTORS.CHAT_MESSAGE);
   }
 
   get chatMessageGroupReceived() {
@@ -294,19 +294,46 @@ class ChatScreen extends UplinkMainScreen {
 
   // Messages Received Methods
 
-  async getLastMessageReceivedText() {
+  async getLastReceivedGroup() {
     const messageGroupsReceived = await this.chatMessageGroupReceived;
     const lastGroupIndex = (await messageGroupsReceived.length) - 1;
-    const messagesInGroup = await $$(SELECTORS.CHAT_MESSAGE_GROUP_REMOTE)[
-      lastGroupIndex
-    ].$$(SELECTORS.CHAT_MESSAGE);
+    const lastGroupLocator = await messageGroupsReceived[lastGroupIndex];
+    return lastGroupLocator;
+  }
+
+  async getLastMessageReceivedLocator() {
+    const lastReceivedGroup = await this.getLastReceivedGroup();
+    const messagesInGroup = await lastReceivedGroup.$$(SELECTORS.CHAT_MESSAGE);
     const lastMessageIndex = (await messagesInGroup.length) - 1;
-    const lastMessageText = await $$(SELECTORS.CHAT_MESSAGE_GROUP_REMOTE)
-      [lastGroupIndex].$$(SELECTORS.CHAT_MESSAGE)
-      [lastMessageIndex].$(SELECTORS.CHAT_MESSAGE_TEXT_GROUP)
+    const lastMessageLocator = await messagesInGroup[lastMessageIndex];
+    return lastMessageLocator;
+  }
+
+  async getLastMessageReceivedText() {
+    const lastMessage = await this.getLastMessageReceivedLocator();
+    const lastMessageText = await lastMessage
+      .$(SELECTORS.CHAT_MESSAGE_TEXT_GROUP)
       .$(SELECTORS.CHAT_MESSAGE_TEXT_VALUE)
       .getText();
     return lastMessageText;
+  }
+
+  async getLastMessageReceivedTimeAgo() {
+    const lastGroupReceived = await this.getLastReceivedGroup();
+    const timeAgoText = await lastGroupReceived
+      .$(SELECTORS.CHAT_MESSAGE_TIME_AGO)
+      .$(SELECTORS.CHAT_MESSAGE_TIME_AGO_TEXT)
+      .getText();
+    return timeAgoText;
+  }
+
+  async getLastMessageReceivedUsername() {
+    const lastGroupReceived = await this.getLastReceivedGroup();
+    const sender = await lastGroupReceived
+      .$(SELECTORS.CHAT_MESSAGE_SENDER)
+      .$(SELECTORS.CHAT_MESSAGE_SENDER_VALUE)
+      .getText();
+    return sender;
   }
 
   // Messages Sent Methods

--- a/tests/screenobjects/ChatScreen.ts
+++ b/tests/screenobjects/ChatScreen.ts
@@ -5,19 +5,27 @@ let SELECTORS = {};
 
 const SELECTORS_COMMON = {
   CHAT_LAYOUT: "~chat-layout",
-  SIDEBAR_CHATS_SECTION: "~Chats",
 };
 
 const SELECTORS_WINDOWS = {
   CHAT_MESSAGE: '[name="Message"]',
-  CHAT_MESSAGE_TEXT: "//Text",
-  INPUT_BUTTON: "//Button",
+  CHAT_MESSAGE_GROUP_REMOTE: '[name="message-group-remote"]',
+  CHAT_MESSAGE_GROUP_SENT: '[name="message-group"]',
+  CHAT_MESSAGE_GROUP_WRAP: '[name="message-group-wrap"]',
+  CHAT_MESSAGE_REPLY: '[name="message-reply"]',
+  CHAT_MESSAGE_SENDER: '[name="sender"]',
+  CHAT_MESSAGE_SENDER_VALUE: "//Text",
+  CHAT_MESSAGE_TEXT_GROUP: '[name="message-text"]',
+  CHAT_MESSAGE_TEXT_VALUE: "//Text",
+  CHAT_MESSAGE_TIME_AGO: '[name="time-ago"]',
+  CHAT_MESSAGE_TIME_AGO_TEXT: "//Text",
+  CHAT_USER_IMAGE: '[name="User Image"]',
+  CHAT_USER_IMAGE_WRAP: '[name="user-image-wrap"]',
+  CHAT_USER_INDICATOR_OFFLINE: '[name="indicator-offline"]',
+  CHAT_USER_INDICATOR_ONLINE: '[name="indicator-online"]',
+  INPUT_GROUP: '[name="input-group"]',
   INPUT_TEXT: "//Edit",
-  SIDEBAR_CHATS_USER: '[name="User"]',
-  SIDEBAR_CHATS_USER_IMAGE: '[name="User Image"]',
-  SIDEBAR_CHATS_USER_INFO: '[name="User Info"]',
-  SIDEBAR_CHATS_USER_NAME: '[name="Username"]',
-  SIDEBAR_CHATS_USER_STATUS: '[name="User Status"]',
+  SEND_MESSAGE_BUTTON: '[name="send-message-button"]',
   TOOLTIP: '[name="tooltip"]',
   TOOLTIP_TEXT: "//Group/Text",
   TOPBAR: '[name="Topbar"]',
@@ -26,19 +34,28 @@ const SELECTORS_WINDOWS = {
   TOPBAR_USER_IMAGE: '[name="User Image"]',
   TOPBAR_USER_NAME: "//Text",
   TOPBAR_VIDEOCALL: '[name="Videocall"]',
+  UPLOAD_BUTTON: '[name="upload-button"]',
 };
 
 const SELECTORS_MACOS = {
   CHAT_MESSAGE: "~Message",
-  CHAT_MESSAGE_TEXT:
-    "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText",
-  INPUT_BUTTON: "-ios class chain:**/XCUIElementTypeButton",
+  CHAT_MESSAGE_GROUP_REMOTE: "~message-group-remote",
+  CHAT_MESSAGE_GROUP_SENT: "~message-group",
+  CHAT_MESSAGE_GROUP_WRAP: "~message-group-wrap",
+  CHAT_MESSAGE_REPLY: "~message-reply",
+  CHAT_MESSAGE_SENDER: "~sender",
+  CHAT_MESSAGE_SENDER_VALUE: "-ios class chain:**/XCUIElementTypeStaticText",
+  CHAT_MESSAGE_TEXT_GROUP: "~message-text",
+  CHAT_MESSAGE_TEXT_VALUE: "-ios class chain:**/XCUIElementTypeStaticText",
+  CHAT_MESSAGE_TIME_AGO: "~time-ago",
+  CHAT_MESSAGE_TIME_AGO_TEXT: "-ios class chain:**/XCUIElementTypeStaticText",
+  CHAT_USER_IMAGE: "~User Image",
+  CHAT_USER_IMAGE_WRAP: "~user-image-wrap",
+  CHAT_USER_INDICATOR_OFFLINE: "~indicator-offline",
+  CHAT_USER_INDICATOR_ONLINE: "~indicator-online",
+  INPUT_GROUP: "~input-group",
   INPUT_TEXT: "-ios class chain:**/XCUIElementTypeTextView",
-  SIDEBAR_CHATS_USER: "~User",
-  SIDEBAR_CHATS_USER_IMAGE: "~User Image",
-  SIDEBAR_CHATS_USER_INFO: "~User Info",
-  SIDEBAR_CHATS_USER_NAME: "~Username",
-  SIDEBAR_CHATS_USER_STATUS: "~User Status",
+  SEND_MESSAGE_BUTTON: "~send-message-button",
   TOOLTIP: "~tooltip",
   TOOLTIP_TEXT:
     "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText",
@@ -48,6 +65,7 @@ const SELECTORS_MACOS = {
   TOPBAR_USER_IMAGE: "~User Image",
   TOPBAR_USER_NAME: "-ios class chain:**/XCUIElementTypeStaticText",
   TOPBAR_VIDEOCALL: "~Videocall",
+  UPLOAD_BUTTON: "~upload-button",
 };
 
 currentOS === "windows"
@@ -64,79 +82,99 @@ class ChatScreen extends UplinkMainScreen {
   }
 
   get chatMessage() {
-    return $(SELECTORS.CHAT_LAYOUT).$(SELECTORS.CHAT_MESSAGE);
+    return $$(SELECTORS.MESSAGE_GROUP).$$(SELECTORS.CHAT_MESSAGE);
   }
 
-  get chatMessageText() {
-    return $(SELECTORS.CHAT_LAYOUT)
-      .$(SELECTORS.CHAT_MESSAGE)
-      .$(SELECTORS.CHAT_MESSAGE_TEXT);
+  get chatMessageGroupReceived() {
+    return $$(SELECTORS.CHAT_MESSAGE_GROUP_REMOTE);
   }
 
-  get inputSendButton() {
-    return $(SELECTORS.CHAT_LAYOUT).$$(SELECTORS.INPUT_BUTTON)[1];
+  get chatMessageGroupSent() {
+    return $$(SELECTORS.CHAT_MESSAGE_GROUP_SENT);
   }
 
-  get inputSendTooltip() {
-    return $(SELECTORS.TOPBAR).$$(SELECTORS.TOOLTIP)[1];
+  get chatMessageGroupWrap() {
+    return $$(SELECTORS.CHAT_MESSAGE_GROUP_WRAP);
+  }
+
+  get chatMessageReply() {
+    return $(SELECTORS.MESSAGE_GROUP).$(SELECTORS.CHAT_MESSAGE_REPLY);
+  }
+
+  get chatMessageSender() {
+    return $$(SELECTORS.MESSAGE_GROUP).$(SELECTORS.CHAT_MESSAGE_SENDER);
+  }
+
+  get chatMessageSenderValue() {
+    return $$(SELECTORS.MESSAGE_GROUP)
+      .$(SELECTORS.CHAT_MESSAGE_SENDER)
+      .$(SELECTORS.CHAT_MESSAGE_SENDER_VALUE);
+  }
+
+  get chatMessageTextValue() {
+    return $$(SELECTORS.CHAT_MESSAGE_TEXT_GROUP).$(
+      SELECTORS.CHAT_MESSAGE_TEXT_VALUE
+    );
+  }
+
+  get chatMessageTextGroup() {
+    return $$(SELECTORS.CHAT_MESSAGE_TEXT_GROUP);
+  }
+
+  get chatMessageTimeAgo() {
+    return $$(SELECTORS.MESSAGE_GROUP).$(SELECTORS.CHAT_MESSAGE_TIME_AGO);
+  }
+
+  get chatMessageTimeAgoValue() {
+    return $$(SELECTORS.MESSAGE_GROUP)
+      .$(SELECTORS.CHAT_MESSAGE_TIME_AGO)
+      .$(SELECTORS.CHAT_MESSAGE_TIME_AGO_TEXT);
+  }
+
+  get chatMessageUserImage() {
+    return $$(SELECTORS.MESSAGE_GROUP)
+      .$(SELECTORS.CHAT_USER_IMAGE_WRAP)
+      .$(SELECTORS.CHAT_USER_IMAGE);
+  }
+
+  get chatMessageUserImageWrap() {
+    return $$(SELECTORS.MESSAGE_GROUP).$(SELECTORS.CHAT_USER_IMAGE_WRAP);
+  }
+
+  get chatMessageUserIndicatorOffline() {
+    return $$(SELECTORS.MESSAGE_GROUP)
+      .$(SELECTORS.CHAT_USER_IMAGE_WRAP)
+      .$(SELECTORS.CHAT_USER_INDICATOR_OFFLINE);
+  }
+
+  get chatMessageUserIndicatorOnline() {
+    return $$(SELECTORS.MESSAGE_GROUP)
+      .$(SELECTORS.CHAT_USER_IMAGE_WRAP)
+      .$(SELECTORS.CHAT_USER_INDICATOR_ONLINE);
+  }
+
+  get inputGroup() {
+    return $(SELECTORS.INPUT_GROUP);
   }
 
   get inputText() {
-    return $(SELECTORS.CHAT_LAYOUT).$(SELECTORS.INPUT_TEXT);
+    return $(SELECTORS.CHAT_LAYOUT)
+      .$(SELECTORS.INPUT_GROUP)
+      .$(SELECTORS.INPUT_TEXT);
   }
 
-  get inputSendTooltipText() {
-    return $(SELECTORS.TOPBAR)
+  get sendMessageButton() {
+    return $(SELECTORS.SEND_MESSAGE_BUTTON);
+  }
+
+  get sendMessageTooltip() {
+    return $(SELECTORS.CHAT_LAYOUT).$$(SELECTORS.TOOLTIP)[1];
+  }
+
+  get sendMessageTooltipText() {
+    return $(SELECTORS.CHAT_LAYOUT)
       .$$(SELECTORS.TOOLTIP)[1]
       .$(SELECTORS.TOOLTIP_TEXT);
-  }
-
-  get inputUploadButton() {
-    return $(SELECTORS.CHAT_LAYOUT).$$(SELECTORS.INPUT_BUTTON)[0];
-  }
-
-  get inputUploadTooltip() {
-    return $(SELECTORS.TOPBAR).$$(SELECTORS.TOOLTIP)[0];
-  }
-
-  get inputUploadTooltipText() {
-    return $(SELECTORS.TOPBAR)
-      .$$(SELECTORS.TOOLTIP)[0]
-      .$(SELECTORS.TOOLTIP_TEXT);
-  }
-
-  get sidebarChatsSection() {
-    return $(SELECTORS.SIDEBAR_CHATS_SECTION);
-  }
-
-  get sidebarChatsUser() {
-    return $(SELECTORS.SIDEBAR_CHATS_SECTION).$$(SELECTORS.SIDEBAR_CHATS_USER);
-  }
-
-  get sidebarChatsUserImage() {
-    return $(SELECTORS.SIDEBAR_CHATS_SECTION)
-      .$(SELECTORS.SIDEBAR_CHATS_USER)
-      .$$(SELECTORS.SIDEBAR_CHATS_USER_IMAGE);
-  }
-
-  get sidebarChatsUserInfo() {
-    return $(SELECTORS.SIDEBAR_CHATS_SECTION)
-      .$(SELECTORS.SIDEBAR_CHATS_USER)
-      .$$(SELECTORS.SIDEBAR_CHATS_USER_INFO);
-  }
-
-  get sidebarChatsUserName() {
-    return $(SELECTORS.SIDEBAR_CHATS_SECTION)
-      .$(SELECTORS.SIDEBAR_CHATS_USER)
-      .$$(SELECTORS.SIDEBAR_CHATS_USER_INFO)
-      .$(SELECTORS.SIDEBAR_CHATS_USER_NAME);
-  }
-
-  get sidebarChatsUserStatus() {
-    return $(SELECTORS.SIDEBAR_CHATS_SECTION)
-      .$(SELECTORS.SIDEBAR_CHATS_USER)
-      .$$(SELECTORS.SIDEBAR_CHATS_USER_INFO)
-      .$(SELECTORS.SIDEBAR_CHATS_USER_STATUS);
   }
 
   get topbar() {
@@ -191,6 +229,132 @@ class ChatScreen extends UplinkMainScreen {
     return $(SELECTORS.TOPBAR)
       .$$(SELECTORS.TOOLTIP)[2]
       .$(SELECTORS.TOOLTIP_TEXT);
+  }
+
+  get uploadButton() {
+    return $(SELECTORS.UPLOAD_BUTTON);
+  }
+
+  get uploadTooltip() {
+    return $(SELECTORS.CHAT_LAYOUT).$$(SELECTORS.TOOLTIP)[0];
+  }
+
+  get uploadTooltipText() {
+    return $(SELECTORS.CHAT_LAYOUT)
+      .$$(SELECTORS.TOOLTIP)[0]
+      .$(SELECTORS.TOOLTIP_TEXT);
+  }
+
+  // Input Bar Methods
+
+  async clearInputBar() {
+    await (await this.inputText).clearValue();
+  }
+
+  async clickOnSendMessage() {
+    await this.sendMessageButton.click();
+  }
+
+  async clickOnUploadFile() {
+    await this.uploadButton.click();
+  }
+
+  // Message Group Wraps Methods
+
+  async getLastGroupWrap() {
+    const messageGroupWraps = await this.chatMessageGroupWrap;
+    const lastGroupWrapIndex = (await messageGroupWraps.length) - 1;
+    const lastGroupWrap = await messageGroupWraps[lastGroupWrapIndex];
+    return lastGroupWrap;
+  }
+
+  async getLastGroupWrapImage() {
+    const groupWrap = await this.getLastGroupWrap();
+    const userImage = await groupWrap
+      .$(SELECTORS.CHAT_USER_IMAGE_WRAP)
+      .$(SELECTORS.CHAT_USER_IMAGE);
+    return userImage;
+  }
+
+  async getLastGroupWrapOffline() {
+    const groupWrap = await this.getLastGroupWrap();
+    const offlineStatus = await groupWrap.$(
+      SELECTORS.CHAT_USER_INDICATOR_OFFLINE
+    );
+    return offlineStatus;
+  }
+
+  async getLastGroupWrapOnline() {
+    const groupWrap = await this.getLastGroupWrap();
+    const onlineStatus = await groupWrap.$(
+      SELECTORS.CHAT_USER_INDICATOR_ONLINE
+    );
+    return onlineStatus;
+  }
+
+  // Messages Received Methods
+
+  async getLastMessageReceivedText() {
+    const messageGroupsReceived = await this.chatMessageGroupReceived;
+    const lastGroupIndex = (await messageGroupsReceived.length) - 1;
+    const messagesInGroup = await $$(SELECTORS.CHAT_MESSAGE_GROUP_REMOTE)[
+      lastGroupIndex
+    ].$$(SELECTORS.CHAT_MESSAGE);
+    const lastMessageIndex = (await messagesInGroup.length) - 1;
+    const lastMessageText = await $$(SELECTORS.CHAT_MESSAGE_GROUP_REMOTE)
+      [lastGroupIndex].$$(SELECTORS.CHAT_MESSAGE)
+      [lastMessageIndex].$(SELECTORS.CHAT_MESSAGE_TEXT_GROUP)
+      .$(SELECTORS.CHAT_MESSAGE_TEXT_VALUE)
+      .getText();
+    return lastMessageText;
+  }
+
+  // Messages Sent Methods
+
+  async getLastSentGroup() {
+    const messageGroupsSent = await this.chatMessageGroupSent;
+    const lastGroupIndex = (await messageGroupsSent.length) - 1;
+    const lastGroupLocator = await messageGroupsSent[lastGroupIndex];
+    return lastGroupLocator;
+  }
+
+  async getLastMessageSentLocator() {
+    const lastSentGroup = await this.getLastSentGroup();
+    const messagesInGroup = await lastSentGroup.$$(SELECTORS.CHAT_MESSAGE);
+    const lastMessageIndex = (await messagesInGroup.length) - 1;
+    const lastMessageLocator = await messagesInGroup[lastMessageIndex];
+    return lastMessageLocator;
+  }
+
+  async getLastMessageSentText() {
+    const lastMessage = await this.getLastMessageSentLocator();
+    const lastMessageText = await lastMessage
+      .$(SELECTORS.CHAT_MESSAGE_TEXT_GROUP)
+      .$(SELECTORS.CHAT_MESSAGE_TEXT_VALUE)
+      .getText();
+    return lastMessageText;
+  }
+
+  async getLastMessageSentTimeAgo() {
+    const lastGroupSent = await this.getLastSentGroup();
+    const timeAgoText = await lastGroupSent
+      .$(SELECTORS.CHAT_MESSAGE_TIME_AGO)
+      .$(SELECTORS.CHAT_MESSAGE_TIME_AGO_TEXT)
+      .getText();
+    return timeAgoText;
+  }
+
+  async getLastMessageSentUsername() {
+    const lastGroupSent = await this.getLastSentGroup();
+    const sender = await lastGroupSent
+      .$(SELECTORS.CHAT_MESSAGE_SENDER)
+      .$(SELECTORS.CHAT_MESSAGE_SENDER_VALUE)
+      .getText();
+    return sender;
+  }
+
+  async typeMessageOnInput(text: string) {
+    await (await this.inputText).setValue(text);
   }
 }
 

--- a/tests/screenobjects/FriendsScreen.ts
+++ b/tests/screenobjects/FriendsScreen.ts
@@ -22,10 +22,6 @@ const SELECTORS_WINDOWS = {
   CONTEXT_MENU: '[name="Context Menu"]',
   CONTEXT_MENU_OPTION: '[name="Context Item"]',
   COPY_ID_BUTTON: '[name="Copy ID"]',
-  FAVORITES: '[name="Favorites"]',
-  FAVORITES_USER: "//Group",
-  FAVORITES_USER_IMAGE: "//Group/Image",
-  FAVORITES_USER_NAME: "//Text/Text",
   FRIEND_INFO: '[name="Friend Info"]',
   FRIEND_INFO_USERNAME: "//Text[1]",
   FRIEND_INFO_USERCODE: "//Text[2]",
@@ -59,12 +55,6 @@ const SELECTORS_MACOS = {
   CONTEXT_MENU: "~Context Menu",
   CONTEXT_MENU_OPTION: "~Context Item",
   COPY_ID_BUTTON: "~Copy ID",
-  FAVORITES: "~Favorites",
-  FAVORITES_USER: "-ios class chain:**/XCUIElementTypeGroup",
-  FAVORITES_USER_IMAGE:
-    '-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeGroup/XCUIElementTypeGroup[`label == "User Image"`]',
-  FAVORITES_USER_NAME:
-    "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText/XCUIElementTypeStaticText",
   FRIEND_INFO: "~Friend Info",
   FRIEND_INFO_USERNAME:
     "-ios class chain:**/XCUIElementTypeGroup[1]/XCUIElementTypeStaticText[1]",
@@ -156,22 +146,6 @@ class FriendsScreen extends UplinkMainScreen {
 
   get copyIdButton() {
     return $(SELECTORS.FRIENDS_BODY).$(SELECTORS.COPY_ID_BUTTON);
-  }
-
-  get favorites() {
-    return $(SELECTORS.FAVORITES);
-  }
-
-  get favoriteUsers() {
-    return $(SELECTORS.FAVORITES).$$(SELECTORS.FAVORITES_USER);
-  }
-
-  get favoritesUserImage() {
-    return $(SELECTORS.FAVORITES).$$(SELECTORS.FAVORITES_USER_IMAGE);
-  }
-
-  get favoritesUserName() {
-    return $(SELECTORS.FAVORITES).$$(SELECTORS.FAVORITES_USER_NAME);
   }
 
   get friendInfo() {
@@ -416,15 +390,6 @@ class FriendsScreen extends UplinkMainScreen {
       .$(SELECTORS.FRIEND_INFO_USERNAME)
       .getText();
     return firstUserFromList;
-  }
-
-  async getUsersFromFavorites() {
-    const favoriteUsers = await this.favoritesUserName;
-    let currentFavoriteUsers = [];
-    for (let name of favoriteUsers) {
-      currentFavoriteUsers.push(await (await $(name)).getText());
-    }
-    return currentFavoriteUsers;
   }
 
   async goToAllFriendsList() {

--- a/tests/screenobjects/UplinkMainScreen.ts
+++ b/tests/screenobjects/UplinkMainScreen.ts
@@ -5,6 +5,7 @@ let SELECTORS = {};
 
 const SELECTORS_COMMON = {
   PRE_RELEASE_INDICATOR: "~pre-release",
+  SIDEBAR_CHATS_SECTION: "~Chats",
 };
 
 const SELECTORS_WINDOWS = {
@@ -15,11 +16,30 @@ const SELECTORS_WINDOWS = {
   BUTTON_NAV_TOOLTIP_TEXT: "//Text",
   CHAT_SEARCH_INPUT: '[name="chat-search-input"]',
   CHATS_BUTTON: '[name="chats-button"]',
+  FAVORITES: '[name="Favorites"]',
+  FAVORITES_HEADER: "//Text/Text",
+  FAVORITES_USER: "//Group",
+  FAVORITES_USER_IMAGE: '[name="User Image"]',
+  FAVORITES_USER_IMAGE_WRAP: '[name="user-image-wrap"]',
+  FAVORITES_USER_INDICATOR_OFFLINE: '[name="indicator-offline"]',
+  FAVORITES_USER_INDICATOR_ONLINE: '[name="indicator-online"]',
+  FAVORITES_USER_NAME: "//Text/Text",
   FILES_BUTTON: '[name="files-button"]',
   FRIENDS_BUTTON: '[name="friends-button"]',
   PRE_RELEASE_INDICATOR_TEXT: "//Text",
   SETTINGS_BUTTON: '[name="settings-button"]',
   SIDEBAR: '[name="sidebar"]',
+  SIDEBAR_CHATS_HEADER: "//Text/Text",
+  SIDEBAR_CHATS_USER: '[name="User"]',
+  SIDEBAR_CHATS_USER_IMAGE: '[name="User Image"]',
+  SIDEBAR_CHATS_USER_IMAGE_WRAP: '[name="user-image-wrap"]',
+  SIDEBAR_CHATS_USER_INFO: '[name="User Info"]',
+  SIDEBAR_CHATS_USER_NAME: '[name="Username"]',
+  SIDEBAR_CHATS_USER_NAME_VALUE: "//Text",
+  SIDEBAR_CHATS_USER_OFFLINE_INDICATOR: '[name="indicator-offline"]',
+  SIDEBAR_CHATS_USER_ONLINE_INDICATOR: '[name="indicator-online"]',
+  SIDEBAR_CHATS_USER_STATUS: '[name="User Status"]',
+  SIDEBAR_CHATS_USER_STATUS_VALUE: "//Text",
   SIDEBAR_CHILDREN: '[name="sidebar-children"]',
   SIDEBAR_SEARCH: '[name="sidebar-search"]',
   SKELETAL_USER: '[name="skeletal-user"]',
@@ -36,11 +56,35 @@ const SELECTORS_MACOS = {
     "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText",
   CHAT_SEARCH_INPUT: "~chat-search-input",
   CHATS_BUTTON: "~chats-button",
+  FAVORITES: "~Favorites",
+  FAVORITES_HEADER:
+    "-ios class chain:**/XCUIElementTypeStaticText/XCUIElementTypeStaticText",
+  FAVORITES_USER: "-ios class chain:**/XCUIElementTypeGroup",
+  FAVORITES_USER_IMAGE_WRAP: "~user-image-wrap",
+  FAVORITES_USER_IMAGE: "~User Image",
+  FAVORITES_USER_INDICATOR_OFFLINE: "~indicator-offline",
+  FAVORITES_USER_INDICATOR_ONLINE: "~indicator-online",
+  FAVORITES_USER_NAME:
+    "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText/XCUIElementTypeStaticText",
   FILES_BUTTON: "~files-button",
   FRIENDS_BUTTON: "~friends-button",
   PRE_RELEASE_INDICATOR_TEXT: "-ios class chain:**/XCUIElementTypeStaticText",
   SETTINGS_BUTTON: "~settings-button",
   SIDEBAR: "~sidebar",
+  SIDEBAR_CHATS_HEADER:
+    "-ios class chain:**/XCUIElementTypeStaticText/XCUIElementTypeStaticText",
+  SIDEBAR_CHATS_USER: "~User",
+  SIDEBAR_CHATS_USER_IMAGE: "~User Image",
+  SIDEBAR_CHATS_USER_IMAGE_WRAP: "~user-image-wrap",
+  SIDEBAR_CHATS_USER_INFO: "~User Info",
+  SIDEBAR_CHATS_USER_NAME: "~Username",
+  SIDEBAR_CHATS_USER_NAME_VALUE:
+    "-ios class chain:**/XCUIElementTypeStaticText",
+  SIDEBAR_CHATS_USER_OFFLINE_INDICATOR: "~indicator-offline",
+  SIDEBAR_CHATS_USER_ONLINE_INDICATOR: "~indicator-online",
+  SIDEBAR_CHATS_USER_STATUS: "~User Status",
+  SIDEBAR_CHATS_USER_STATUS_VALUE:
+    "-ios class chain:**/XCUIElementTypeStaticText",
   SIDEBAR_CHILDREN: "~sidebar-children",
   SIDEBAR_SEARCH: "~sidebar-search",
   SKELETAL_USER: "~skeletal-user",
@@ -85,6 +129,40 @@ export default class UplinkMainScreen extends AppScreen {
     return $(SELECTORS.BUTTON_NAV)
       .$$(SELECTORS.TOOLTIP)[0]
       .$(SELECTORS.BUTTON_NAV_TOOLTIP_TEXT);
+  }
+
+  get favorites() {
+    return $(SELECTORS.FAVORITES);
+  }
+
+  get favoritesHeader() {
+    return $(SELECTORS.FAVORITES).$(SELECTORS.FAVORITES_HEADER);
+  }
+
+  get favoriteUsers() {
+    return $(SELECTORS.FAVORITES).$$(SELECTORS.FAVORITES_USER);
+  }
+
+  get favoritesUserImage() {
+    return $(SELECTORS.FAVORITES).$$(SELECTORS.FAVORITES_USER_IMAGE);
+  }
+
+  get favoritesUserImageWrap() {
+    return $(SELECTORS.FAVORITES).$$(SELECTORS.FAVORITES_USER_IMAGE_WRAP);
+  }
+
+  get favoritesUserIndicatorOffline() {
+    return $(SELECTORS.FAVORITES).$$(
+      SELECTORS.FAVORITES_USER_INDICATOR_OFFLINE
+    );
+  }
+
+  get favoritesUserIndicatorOnline() {
+    return $(SELECTORS.FAVORITES).$$(SELECTORS.FAVORITES_USER_INDICATOR_ONLINE);
+  }
+
+  get favoritesUserName() {
+    return $(SELECTORS.FAVORITES).$$(SELECTORS.FAVORITES_USER_NAME);
   }
 
   get filesButton() {
@@ -143,6 +221,75 @@ export default class UplinkMainScreen extends AppScreen {
     return $(SELECTORS.SIDEBAR);
   }
 
+  get siderbarChatsHeader() {
+    return $(SELECTORS.SIDEBAR_CHATS_SECTION).$(
+      SELECTORS.SIDERBAR_CHATS_HEADER
+    );
+  }
+
+  get sidebarChatsSection() {
+    return $(SELECTORS.SIDEBAR_CHATS_SECTION);
+  }
+
+  get sidebarChatsUser() {
+    return $(SELECTORS.SIDEBAR_CHATS_SECTION).$$(SELECTORS.SIDEBAR_CHATS_USER);
+  }
+
+  get sidebarChatsUserImage() {
+    return $(SELECTORS.SIDEBAR_CHATS_SECTION)
+      .$(SELECTORS.SIDEBAR_CHATS_USER)
+      .$$(SELECTORS.SIDEBAR_CHATS_USER_IMAGE);
+  }
+
+  get sidebarChatsUserImageWrap() {
+    return $(SELECTORS.SIDEBAR_CHATS_SECTION)
+      .$(SELECTORS.SIDEBAR_CHATS_USER)
+      .$$(SELECTORS.SIDEBAR_CHATS_USER_IMAGE_WRAP);
+  }
+
+  get sidebarChatsUserInfo() {
+    return $(SELECTORS.SIDEBAR_CHATS_SECTION)
+      .$(SELECTORS.SIDEBAR_CHATS_USER)
+      .$$(SELECTORS.SIDEBAR_CHATS_USER_INFO);
+  }
+
+  get sidebarChatsUserName() {
+    return $(SELECTORS.SIDEBAR_CHATS_SECTION)
+      .$(SELECTORS.SIDEBAR_CHATS_USER)
+      .$(SELECTORS.SIDEBAR_CHATS_USER_NAME);
+  }
+  get sidebarChatsUserNameValue() {
+    return $(SELECTORS.SIDEBAR_CHATS_SECTION)
+      .$(SELECTORS.SIDEBAR_CHATS_USER)
+      .$(SELECTORS.SIDEBAR_CHATS_USER_NAME)
+      .$(SELECTORS.SIDEBAR_CHATS_USER_NAME_VALUE);
+  }
+
+  get sidebarChatsUserOfflineIndicator() {
+    return $$(SELECTORS.SIDEBAR_CHATS_SECTION)
+      .$(SELECTORS.SIDEBAR_CHATS_USER_IMAGE)
+      .$(SELECTORS.SIDEBAR_CHATS_USER_OFFLINE_INDICATOR);
+  }
+
+  get sidebarChatsUserOnlineIndicator() {
+    return $$(SELECTORS.SIDEBAR_CHATS_SECTION)
+      .$(SELECTORS.SIDEBAR_CHATS_USER_IMAGE)
+      .$(SELECTORS.SIDEBAR_CHATS_USER_ONLINE_INDICATOR);
+  }
+
+  get sidebarChatsUserStatus() {
+    return $(SELECTORS.SIDEBAR_CHATS_SECTION)
+      .$(SELECTORS.SIDEBAR_CHATS_USER)
+      .$(SELECTORS.SIDEBAR_CHATS_USER_STATUS);
+  }
+
+  get sidebarChatsUserStatusValue() {
+    return $(SELECTORS.SIDEBAR_CHATS_SECTION)
+      .$(SELECTORS.SIDEBAR_CHATS_USER)
+      .$(SELECTORS.SIDEBAR_CHATS_USER_STATUS)
+      .$(SELECTORS.SIDEBAR_CHATS_USER_STATUS_VALUE);
+  }
+
   get sidebarChildren() {
     return $(SELECTORS.SIDEBAR_CHILDREN);
   }
@@ -174,6 +321,15 @@ export default class UplinkMainScreen extends AppScreen {
       "XCUIElementTypeButton"
     );
     await (await $(closeButton)).click();
+  }
+
+  async getUsersFromFavorites() {
+    const favoriteUsers = await this.favoritesUserName;
+    let currentFavoriteUsers = [];
+    for (let name of favoriteUsers) {
+      currentFavoriteUsers.push(await (await $(name)).getText());
+    }
+    return currentFavoriteUsers;
   }
 
   async goToFiles() {

--- a/tests/specs/04-friends.spec.ts
+++ b/tests/specs/04-friends.spec.ts
@@ -76,6 +76,8 @@ export default async function friends() {
 
     //Validate Chat Screen is displayed and go back to Friends Screen
     await ChatScreen.waitForIsShown(true);
+    await ChatScreen.typeMessageOnInput("testing...");
+    await ChatScreen.clearInputBar();
     await ChatScreen.goToFriends();
     await FriendsScreen.waitForIsShown(true);
   });
@@ -185,6 +187,8 @@ export default async function friends() {
     // Select first option "Chat" from Context Menu and validate Chat is displayed
     await FriendsScreen.contextMenuOption[0].click();
     await ChatScreen.waitForIsShown(true);
+    await ChatScreen.typeMessageOnInput("testing...");
+    await ChatScreen.clearInputBar();
 
     // Go back to Friends Screen
     await ChatScreen.goToFriends();

--- a/tests/specs/reusable-accounts/01-chats-userA.spec.ts
+++ b/tests/specs/reusable-accounts/01-chats-userA.spec.ts
@@ -61,7 +61,7 @@ describe("Two users at the same time - Chat User A", async () => {
 
     //Timestamp from last message sent should be displayed
     const timeAgo = await ChatScreen.getLastMessageSentTimeAgo();
-    await expect(timeAgo).toHaveTextContaining("seconds ago");
+    await expect(timeAgo).toContain("seconds ago");
 
     // At the end of testing, wait for 30 seconds before ending session
     await browser.pause(30000);

--- a/tests/specs/reusable-accounts/01-chats-userA.spec.ts
+++ b/tests/specs/reusable-accounts/01-chats-userA.spec.ts
@@ -39,7 +39,7 @@ describe("Two users at the same time - Chat User A", async () => {
   it("Validate Chat Message displays timestamp", async () => {
     //Timestamp should be displayed when you send a message
     const timeAgo = await ChatScreen.getLastMessageSentTimeAgo();
-    await expect(timeAgo).toContain("seconds ago");
+    await expect(timeAgo).toContain("now");
   });
 
   it("Validate Chat Message displays username who sent it", async () => {

--- a/tests/specs/reusable-accounts/01-chats-userA.spec.ts
+++ b/tests/specs/reusable-accounts/01-chats-userA.spec.ts
@@ -53,9 +53,15 @@ describe("Two users at the same time - Chat User A", async () => {
   });
 
   it("Validate Chat Message displays timestamp", async () => {
-    //Timestamp should be displayed when you send a message
+    // Type a long message and do not send it
+    await ChatScreen.typeMessageOnInput(
+      "this is a looooong message that will not be send"
+    );
+    await ChatScreen.clearInputBar();
+
+    //Timestamp from last message sent should be displayed
     const timeAgo = await ChatScreen.getLastMessageSentTimeAgo();
-    await expect(timeAgo).toHaveTextContaining(["now", "seconds ago"]);
+    await expect(timeAgo).toHaveTextContaining("seconds ago");
 
     // At the end of testing, wait for 30 seconds before ending session
     await browser.pause(30000);

--- a/tests/specs/reusable-accounts/01-chats-userA.spec.ts
+++ b/tests/specs/reusable-accounts/01-chats-userA.spec.ts
@@ -36,12 +36,6 @@ describe("Two users at the same time - Chat User A", async () => {
     await expect(lastMessage).toBeDisplayed();
   });
 
-  it("Validate Chat Message displays timestamp", async () => {
-    //Timestamp should be displayed when you send a message
-    const timeAgo = await ChatScreen.getLastMessageSentTimeAgo();
-    await expect(timeAgo).toContain("now");
-  });
-
   it("Validate Chat Message displays username who sent it", async () => {
     // ChatUserA username should be above of the messages group
     const sender = await ChatScreen.getLastMessageSentUsername();
@@ -56,6 +50,12 @@ describe("Two users at the same time - Chat User A", async () => {
     //Online indicator of your user should be displayed next to the image
     const onlineIndicator = await ChatScreen.getLastGroupWrapOnline();
     await expect(onlineIndicator).toExist();
+  });
+
+  it("Validate Chat Message displays timestamp", async () => {
+    //Timestamp should be displayed when you send a message
+    const timeAgo = await ChatScreen.getLastMessageSentTimeAgo();
+    await expect(timeAgo).toContain("seconds ago");
 
     // At the end of testing, wait for 30 seconds before ending session
     await browser.pause(30000);

--- a/tests/specs/reusable-accounts/01-chats-userA.spec.ts
+++ b/tests/specs/reusable-accounts/01-chats-userA.spec.ts
@@ -28,7 +28,6 @@ describe("Two users at the same time - Chat User A", async () => {
 
     const textFromMessage = await ChatScreen.getLastMessageSentText();
     await expect(textFromMessage).toEqual("testing...");
-    await browser.pause(30000);
   });
 
   it("Validate Chat Message sent contents", async () => {
@@ -40,7 +39,7 @@ describe("Two users at the same time - Chat User A", async () => {
   it("Validate Chat Message displays timestamp", async () => {
     //Timestamp should be displayed when you send a message
     const timeAgo = await ChatScreen.getLastMessageSentTimeAgo();
-    await expect(timeAgo).toEqual("now");
+    await expect(timeAgo).toContain("seconds ago");
   });
 
   it("Validate Chat Message displays username who sent it", async () => {
@@ -57,27 +56,8 @@ describe("Two users at the same time - Chat User A", async () => {
     //Online indicator of your user should be displayed next to the image
     const onlineIndicator = await ChatScreen.getLastGroupWrapOnline();
     await expect(onlineIndicator).toExist();
-  });
 
-  xit("Send friend request flow", async () => {
-    // Send friend request to user B
-    //await FriendsScreen.addSomeoneInput.setValue(userBKey);
-    await FriendsScreen.addSomeoneButton.click();
-
-    // Validate Toast Notification is displayed
-    await (await FriendsScreen.toastNotification).waitForDisplayed();
-    await (
-      await FriendsScreen.toastNotification
-    ).waitForDisplayed({ reverse: true });
-
-    // Wait until friend request is accepted and go to a Chat Conversation with Chat User B
-    await FriendsScreen.goToPendingFriendsList();
-    await (
-      await FriendsScreen.removeOrDenyFriendButton
-    ).waitForExist({ reverse: true, timeout: 180000 });
-
-    // Go to All Friends List and validate Chat with Friend Button is displayed
-    await FriendsScreen.goToAllFriendsList();
-    await (await FriendsScreen.chatWithFriendButton).waitForExist();
+    // At the end of testing, wait for 30 seconds before ending session
+    await browser.pause(30000);
   });
 });

--- a/tests/specs/reusable-accounts/01-chats-userA.spec.ts
+++ b/tests/specs/reusable-accounts/01-chats-userA.spec.ts
@@ -55,7 +55,7 @@ describe("Two users at the same time - Chat User A", async () => {
   it("Validate Chat Message displays timestamp", async () => {
     //Timestamp should be displayed when you send a message
     const timeAgo = await ChatScreen.getLastMessageSentTimeAgo();
-    await expect(timeAgo).toContain("seconds ago");
+    await expect(timeAgo).toHaveTextContaining(["now", "seconds ago"]);
 
     // At the end of testing, wait for 30 seconds before ending session
     await browser.pause(30000);

--- a/tests/specs/reusable-accounts/01-chats-userA.spec.ts
+++ b/tests/specs/reusable-accounts/01-chats-userA.spec.ts
@@ -20,16 +20,43 @@ describe("Two users at the same time - Chat User A", async () => {
     await ChatScreen.waitForIsShown(true);
 
     const paragraph = await faker.lorem.words(30);
-    await (await ChatScreen.inputText).setValue(paragraph);
-    await (await ChatScreen.inputText).clearValue();
+    await ChatScreen.typeMessageOnInput(paragraph);
+    await ChatScreen.clearInputBar();
 
-    await (await ChatScreen.inputText).setValue("testing...");
-    await ChatScreen.inputSendButton.click();
+    await ChatScreen.typeMessageOnInput("testing...");
+    await ChatScreen.clickOnSendMessage();
 
-    await (await ChatScreen.chatMessage).waitForDisplayed();
-    expect(await ChatScreen.chatMessageText).toHaveTextContaining("testing...");
-
+    const textFromMessage = await ChatScreen.getLastMessageSentText();
+    await expect(textFromMessage).toEqual("testing...");
     await browser.pause(30000);
+  });
+
+  it("Validate Chat Message sent contents", async () => {
+    //Any message you sent yourself should appear within a colored message bubble
+    const lastMessage = await ChatScreen.getLastMessageSentLocator();
+    await expect(lastMessage).toBeDisplayed();
+  });
+
+  it("Validate Chat Message displays timestamp", async () => {
+    //Timestamp should be displayed when you send a message
+    const timeAgo = await ChatScreen.getLastMessageSentTimeAgo();
+    await expect(timeAgo).toEqual("now");
+  });
+
+  it("Validate Chat Message displays username who sent it", async () => {
+    // ChatUserA username should be above of the messages group
+    const sender = await ChatScreen.getLastMessageSentUsername();
+    await expect(sender).toEqual("ChatUserA");
+  });
+
+  it("Validate Chat Message Group displays username picture and online indicator", async () => {
+    //Your user image should be displayed next to the message
+    const userImage = await ChatScreen.getLastGroupWrapImage();
+    await expect(userImage).toExist();
+
+    //Online indicator of your user should be displayed next to the image
+    const onlineIndicator = await ChatScreen.getLastGroupWrapOnline();
+    await expect(onlineIndicator).toExist();
   });
 
   xit("Send friend request flow", async () => {

--- a/tests/specs/reusable-accounts/02-chats-userB.spec.ts
+++ b/tests/specs/reusable-accounts/02-chats-userB.spec.ts
@@ -33,12 +33,6 @@ describe("Two users at the same time - Chat User B", async () => {
     await expect(lastMessage).toBeDisplayed();
   });
 
-  it("Validate Chat Message received displays timestamp", async () => {
-    //Timestamp should be displayed when you send a message
-    const timeAgo = await ChatScreen.getLastMessageReceivedTimeAgo();
-    await expect(timeAgo).toContain("seconds ago");
-  });
-
   it("Validate Chat Message received displays username who sent it", async () => {
     // ChatUserA username should be above of the messages group
     const sender = await ChatScreen.getLastMessageReceivedUsername();
@@ -53,5 +47,11 @@ describe("Two users at the same time - Chat User B", async () => {
     //Online indicator of your user should be displayed next to the image
     const onlineIndicator = await ChatScreen.getLastGroupWrapOnline();
     await expect(onlineIndicator).toExist();
+  });
+
+  it("Validate Chat Message received displays timestamp", async () => {
+    //Timestamp should be displayed when you send a message
+    const timeAgo = await ChatScreen.getLastMessageReceivedTimeAgo();
+    await expect(timeAgo).toContain("seconds ago");
   });
 });

--- a/tests/specs/reusable-accounts/02-chats-userB.spec.ts
+++ b/tests/specs/reusable-accounts/02-chats-userB.spec.ts
@@ -50,8 +50,14 @@ describe("Two users at the same time - Chat User B", async () => {
   });
 
   it("Validate Chat Message received displays timestamp", async () => {
+    // Type a long message and do not send it
+    await ChatScreen.typeMessageOnInput(
+      "this is a looooong message that will not be send"
+    );
+    await ChatScreen.clearInputBar();
+
     //Timestamp should be displayed when you send a message
     const timeAgo = await ChatScreen.getLastMessageReceivedTimeAgo();
-    await expect(timeAgo).toHaveTextContaining(["now", "seconds ago"]);
+    await expect(timeAgo).toHaveTextContaining("seconds ago");
   });
 });

--- a/tests/specs/reusable-accounts/02-chats-userB.spec.ts
+++ b/tests/specs/reusable-accounts/02-chats-userB.spec.ts
@@ -58,6 +58,6 @@ describe("Two users at the same time - Chat User B", async () => {
 
     //Timestamp should be displayed when you send a message
     const timeAgo = await ChatScreen.getLastMessageReceivedTimeAgo();
-    await expect(timeAgo).toHaveTextContaining("seconds ago");
+    await expect(timeAgo).toContain("ago");
   });
 });

--- a/tests/specs/reusable-accounts/02-chats-userB.spec.ts
+++ b/tests/specs/reusable-accounts/02-chats-userB.spec.ts
@@ -52,6 +52,6 @@ describe("Two users at the same time - Chat User B", async () => {
   it("Validate Chat Message received displays timestamp", async () => {
     //Timestamp should be displayed when you send a message
     const timeAgo = await ChatScreen.getLastMessageReceivedTimeAgo();
-    await expect(timeAgo).toContain("seconds ago");
+    await expect(timeAgo).toHaveTextContaining(["now", "seconds ago"]);
   });
 });

--- a/tests/specs/reusable-accounts/02-chats-userB.spec.ts
+++ b/tests/specs/reusable-accounts/02-chats-userB.spec.ts
@@ -23,20 +23,35 @@ describe("Two users at the same time - Chat User B", async () => {
     await (await ChatScreen.inputText).clearValue();
 
     await (await ChatScreen.chatMessage).waitForDisplayed({ timeout: 180000 });
-    expect(await ChatScreen.chatMessageText).toHaveTextContaining("testing...");
+    const textFromMessage = await ChatScreen.getLastMessageReceivedText();
+    await expect(textFromMessage).toEqual("testing...");
   });
 
-  xit("Accept friend request from Chat User A flow", async () => {
-    // Accept incoming request from ChatUserA
-    await FriendsScreen.goToPendingFriendsList();
-    await (
-      await FriendsScreen.acceptFriendRequestButton
-    ).waitForExist({ timeout: 180000 });
-    await (await FriendsScreen.acceptFriendRequestButton).click();
+  it("Validate Chat Message received contents", async () => {
+    //Any message you sent yourself should appear within a colored message bubble
+    const lastMessage = await ChatScreen.getLastMessageReceivedLocator();
+    await expect(lastMessage).toBeDisplayed();
+  });
 
-    // Go to the current list of All friends and then open a Chat conversation with ChatUserA
-    await FriendsScreen.goToAllFriendsList();
-    await (await FriendsScreen.chatWithFriendButton).click();
-    await ChatScreen.waitForIsShown(true);
+  it("Validate Chat Message received displays timestamp", async () => {
+    //Timestamp should be displayed when you send a message
+    const timeAgo = await ChatScreen.getLastMessageReceivedTimeAgo();
+    await expect(timeAgo).toContain("seconds ago");
+  });
+
+  it("Validate Chat Message received displays username who sent it", async () => {
+    // ChatUserA username should be above of the messages group
+    const sender = await ChatScreen.getLastMessageReceivedUsername();
+    await expect(sender).toEqual("ChatUserA");
+  });
+
+  it("Validate Chat Message Group from remote user displays username picture and online indicator", async () => {
+    //Your user image should be displayed next to the message
+    const userImage = await ChatScreen.getLastGroupWrapImage();
+    await expect(userImage).toExist();
+
+    //Online indicator of your user should be displayed next to the image
+    const onlineIndicator = await ChatScreen.getLastGroupWrapOnline();
+    await expect(onlineIndicator).toExist();
   });
 });


### PR DESCRIPTION
### What this PR does 📖

- Add and updated windows and macos locators for chat screen UI elements
- Added screenobject methods for new chats tests
- Added new chat tests validating contents of chat message sent

### Which issue(s) this PR fixes 🔨

- Resolve #142 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
