### PR TITLE
test(appium): wait for toasts to close on windows

### DIFF
--- a/config/wdio.shared.conf.ts
+++ b/config/wdio.shared.conf.ts
@@ -100,13 +100,13 @@ export const config: WebdriverIO.Config = {
   // before running any tests.
   framework: "mocha",
   // The number of times to retry the entire specfile when it fails as a whole
-  specFileRetries: 0,
+  specFileRetries: 1,
   //
   // Delay in seconds between the spec file retry attempts
-  // specFileRetriesDelay: 0,
+  specFileRetriesDelay: 10,
   //
   // Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
-  // specFileRetriesDeferred: false,
+  specFileRetriesDeferred: false,
   //
   // Test reporter for stdout.
   // The only one supported by default is 'dot'

--- a/tests/screenobjects/SettingsProfileScreen.ts
+++ b/tests/screenobjects/SettingsProfileScreen.ts
@@ -188,6 +188,11 @@ class SettingsProfileScreen extends SettingsBaseScreen {
     }
   }
 
+  async waitForToastNotificationClosed() {
+    const toast = await $(SELECTORS.TOAST_NOTIFICATIONS);
+    await toast.waitForDisplayed({ reverse: true });
+  }
+
   async uploadBannerPicture(relativePath: string) {
     // Invoke File Selection method depending on current OS driver
     // If Windows driver is running, first retrieve the current context and pass it to file selection function

--- a/tests/specs/05-settings-profile.spec.ts
+++ b/tests/specs/05-settings-profile.spec.ts
@@ -68,6 +68,9 @@ export default async function settingsProfile() {
     await SettingsProfileScreen.uploadProfilePicture(
       "./tests/fixtures/logo.jpg"
     );
+
+    // Wait for toast notification to be closed
+    await SettingsProfileScreen.waitForToastNotificationClosed();
   });
 
   // Skipped for now since it needs research on how to implement hover on Windows Appium Driver
@@ -87,6 +90,11 @@ export default async function settingsProfile() {
     await SettingsProfileScreen.uploadBannerPicture(
       "./tests/fixtures/banner.jpg"
     );
+
+    // Wait for toast notification to be closed
+    await SettingsProfileScreen.waitForToastNotificationClosed();
+
+    // Click on username input
     await (await SettingsProfileScreen.usernameInput).click();
   });
 
@@ -95,6 +103,9 @@ export default async function settingsProfile() {
     await SettingsProfileScreen.uploadProfilePicture(
       "./tests/fixtures/second-profile.png"
     );
+
+    // Wait for toast notification to be closed
+    await SettingsProfileScreen.waitForToastNotificationClosed();
   });
 
   // Needs visual validation steps to ensure that picture was actually loaded matches with expected image
@@ -102,6 +113,9 @@ export default async function settingsProfile() {
     await SettingsProfileScreen.uploadBannerPicture(
       "./tests/fixtures/second-banner.jpg"
     );
+
+    // Wait for toast notification to be closed
+    await SettingsProfileScreen.waitForToastNotificationClosed();
   });
 
   it("Settings Profile - Status with more than 128 characters", async () => {
@@ -115,6 +129,9 @@ export default async function settingsProfile() {
         "Maximum of 128 characters exceeded."
       );
     });
+
+    // Wait for toast notification to be closed
+    await SettingsProfileScreen.waitForToastNotificationClosed();
 
     // Clear value from status input
     await SettingsProfileScreen.deleteStatus();


### PR DESCRIPTION
### What this PR does 📖

- Wait for toast notifications to close on Settings Profile tests, because these are causing issues on Windows CI
- Add one retry for specs to mocha setup

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
