### PR TITLE
chore(appium): add mocha retry to one

### DIFF
--- a/config/wdio.shared.conf.ts
+++ b/config/wdio.shared.conf.ts
@@ -64,7 +64,7 @@ export const config: WebdriverIO.Config = {
   //
   // If you only want to run your tests until a specific amount of tests have failed use
   // bail (default is 0 - don't bail, run all tests).
-  bail: 0,
+  bail: 1,
   // Set a base URL in order to shorten url command calls. If your `url` parameter starts
   // with `/`, the base url gets prepended, not including the path portion of your baseUrl.
   // If your `url` parameter starts without a scheme or `/` (like `some/path`), the base url
@@ -100,10 +100,10 @@ export const config: WebdriverIO.Config = {
   // before running any tests.
   framework: "mocha",
   // The number of times to retry the entire specfile when it fails as a whole
-  specFileRetries: 0,
+  specFileRetries: 1,
   //
   // Delay in seconds between the spec file retry attempts
-  //specFileRetriesDelay: 10,
+  specFileRetriesDelay: 60,
   //
   // Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
   //specFileRetriesDeferred: false,

--- a/tests/helpers/commands.ts
+++ b/tests/helpers/commands.ts
@@ -350,9 +350,7 @@ export async function saveFileOnWindows(
   return;
 }
 
-export async function selectFileOnWindows(
-  relativePath: string,
-) {
+export async function selectFileOnWindows(relativePath: string) {
   // Get the filepath to select on browser
   const filepath = join(process.cwd(), relativePath);
 

--- a/tests/suites/01-UplinkTestSuite.ts
+++ b/tests/suites/01-UplinkTestSuite.ts
@@ -9,8 +9,9 @@ import settingsFiles from "../specs/09-settings-files.spec";
 import settingsExtensions from "../specs/10-settings-extensions.spec";
 import settingsNotifications from "../specs/11-settings-notifications.spec";
 import settingsDeveloper from "../specs/12-settings-developer.spec";
+import { deleteCache } from "../helpers/commands";
 
-describe("Uplink UI Automated Tests", async () => {
+describe("Uplink UI Automated Tests", function () {
   describe("Create Pin and Account Tests", createAccount.bind(this));
   describe("Chats Main Screen Tests", chats.bind(this));
   describe("Files Screen Tests", files.bind(this));
@@ -22,4 +23,8 @@ describe("Uplink UI Automated Tests", async () => {
   describe("Settings Extensions Tests", settingsExtensions.bind(this));
   describe("Settings Notifications Tests", settingsNotifications.bind(this));
   describe("Settings Developer Tests", settingsDeveloper.bind(this));
+
+  after(function () {
+    deleteCache();
+  });
 });

--- a/tests/suites/02-UplinkFriendsSuite.ts
+++ b/tests/suites/02-UplinkFriendsSuite.ts
@@ -1,6 +1,6 @@
 import friends from "../specs/04-friends.spec";
 
 // Note: The following test suite is not running for now on Windows CI due to appium issues that need investigation
-describe("Uplink UI Automated Tests with Reusable Account", async () => {
+describe("Uplink UI Automated Tests with Reusable Account", function () {
   describe("Friends Screen Tests", friends.bind(this));
 });


### PR DESCRIPTION
### What this PR does 📖

- Implemented mocha retry spec to try one more time when a spec fails due to CI issues. 
- Added delete cache after hook because we need to delete cache folder before retrying

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
