### PR TITLE
chore(appium): update windows build step

### DIFF
--- a/.github/workflows/build-cron-job.yml
+++ b/.github/workflows/build-cron-job.yml
@@ -30,7 +30,7 @@ jobs:
               C:\Users\runneradmin\.cargo\registry\cache\
               C:\Users\runneradmin\.cargo\git\db\
               target\
-            build-instruction: cargo build --package ui --release
+            build-instruction: cargo build --release
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout testing directory 🔖


### PR DESCRIPTION
### What this PR does 📖

- We are no longer using package ui, so windows build instruction is changed to cargo build --release

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
