### PR TITLE
chore(appium): add option to run build and test workflows manually

### DIFF
--- a/.github/workflows/build-cron-job.yml
+++ b/.github/workflows/build-cron-job.yml
@@ -3,6 +3,7 @@ name: Build App Windows and MacOS 🧪
 on:
   schedule:
     - cron: "0 0/6 * * 1-5"
+  workflow_dispatch:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -7,6 +7,7 @@ on:
     workflows: [Build App Windows and MacOS 🧪]
     types:
       - completed
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### What this PR does 📖

- Add ability to run Build and Test workflows "manually", by adding "on: workflow_dispatch" option

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
