### PR TITLE
test(add): adding test for replies on chats tests

### DIFF
--- a/tests/screenobjects/ChatScreen.ts
+++ b/tests/screenobjects/ChatScreen.ts
@@ -127,7 +127,7 @@ class ChatScreen extends UplinkMainScreen {
   }
 
   get chatMessageReply() {
-    return $(SELECTORS.MESSAGE_GROUP).$(SELECTORS.CHAT_MESSAGE_REPLY);
+    return $(SELECTORS.CHAT_MESSAGE_REPLY);
   }
 
   get chatMessageReplyText() {
@@ -318,7 +318,7 @@ class ChatScreen extends UplinkMainScreen {
       .$(SELECTORS.TOOLTIP_TEXT);
   }
 
-  // Input Bar Methods
+  // Top Bar Methods
 
   async addToFavorites() {
     await this.topbarAddToFavorites.click();
@@ -327,6 +327,8 @@ class ChatScreen extends UplinkMainScreen {
   async removeFromFavorites() {
     await this.topbarRemoveFromFavorites.click();
   }
+
+  // Input Bar Methods
 
   async clearInputBar() {
     await (await this.inputText).clearValue();
@@ -338,10 +340,6 @@ class ChatScreen extends UplinkMainScreen {
 
   async clickOnUploadFile() {
     await this.uploadButton.click();
-  }
-
-  async closeReplyModal() {
-    await this.replyPopUpCloseButton.click();
   }
 
   // Message Group Wraps Methods
@@ -412,19 +410,21 @@ class ChatScreen extends UplinkMainScreen {
     return timeAgoText;
   }
 
-  async openContextMenuOnReceivedMessage() {
-    const messageToClick = await this.getLastMessageReceivedLocator();
-    const currentDriver = await this.getCurrentDriver();
-    if (currentDriver === "mac2") {
-      await rightClickOnMacOS(messageToClick);
-    } else if (currentDriver === "windows") {
-      await rightClickOnWindows(messageToClick);
-    }
-    await (await this.contextMenu).waitForDisplayed();
+  async getLastReplyReceived() {
+    const lastGroupReceived = await this.getLastReceivedGroup();
+    const lastReplyReceived = await lastGroupReceived.$(
+      SELECTORS.CHAT_MESSAGE_REPLY
+    );
+    return lastReplyReceived;
   }
 
-  async selectContextOption(option: number) {
-    await this.contextMenuOption[option].click();
+  async getLastReplyReceivedText() {
+    const lastGroupReceived = await this.getLastReceivedGroup();
+    const lastReplyReceivedText = await lastGroupReceived
+      .$(SELECTORS.CHAT_MESSAGE_REPLY)
+      .$(SELECTORS.CHAT_MESSAGE_REPLY_TEXT)
+      .getText();
+    return lastReplyReceivedText;
   }
 
   // Messages Sent Methods
@@ -462,6 +462,38 @@ class ChatScreen extends UplinkMainScreen {
     return timeAgoText;
   }
 
+  async getLastReplySent() {
+    const lastGroupSent = await this.getLastSentGroup();
+    const lastReplySent = await lastGroupSent.$(SELECTORS.CHAT_MESSAGE_REPLY);
+    return lastReplySent;
+  }
+
+  async getLastReplySentText() {
+    const lastGroupSent = await this.getLastSentGroup();
+    const lastReplySentText = await lastGroupSent
+      .$(SELECTORS.CHAT_MESSAGE_REPLY)
+      .$(SELECTORS.CHAT_MESSAGE_REPLY_TEXT)
+      .getText();
+    return lastReplySentText;
+  }
+
+  // Context Menu Functions
+
+  async openContextMenuOnReceivedMessage() {
+    const messageToClick = await this.getLastMessageReceivedLocator();
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === "mac2") {
+      await rightClickOnMacOS(messageToClick);
+    } else if (currentDriver === "windows") {
+      await rightClickOnWindows(messageToClick);
+    }
+    await (await this.contextMenu).waitForDisplayed();
+  }
+
+  async selectContextOption(option: number) {
+    await this.contextMenuOption[option].click();
+  }
+
   // Hovering methods
 
   async hoverOnFavoritesButton() {
@@ -478,6 +510,20 @@ class ChatScreen extends UplinkMainScreen {
 
   async typeMessageOnInput(text: string) {
     await (await this.inputText).setValue(text);
+  }
+
+  // Reply Modal methods
+
+  async closeReplyModal() {
+    await this.replyPopUpCloseButton.click();
+  }
+
+  async waitForReplyModalToNotExist() {
+    (await this.replyPopUpCloseButton).waitForExist({ reverse: true });
+  }
+
+  async waitUntilReplyIsReceived() {
+    (await this.chatMessageReply).waitForExist({ timeout: 180000 });
   }
 }
 

--- a/tests/screenobjects/ChatScreen.ts
+++ b/tests/screenobjects/ChatScreen.ts
@@ -521,10 +521,6 @@ class ChatScreen extends UplinkMainScreen {
   async waitForReplyModalToNotExist() {
     (await this.replyPopUpCloseButton).waitForExist({ reverse: true });
   }
-
-  async waitUntilReplyIsReceived() {
-    (await this.chatMessageReply).waitForExist({ timeout: 180000 });
-  }
 }
 
 export default new ChatScreen();

--- a/tests/screenobjects/ChatScreen.ts
+++ b/tests/screenobjects/ChatScreen.ts
@@ -1,3 +1,4 @@
+import { rightClickOnMacOS, rightClickOnWindows } from "../helpers/commands";
 import UplinkMainScreen from "./UplinkMainScreen";
 
 const currentOS = driver.capabilities.automationName;
@@ -13,6 +14,7 @@ const SELECTORS_WINDOWS = {
   CHAT_MESSAGE_GROUP_SENT: '[name="message-group"]',
   CHAT_MESSAGE_GROUP_WRAP: '[name="message-group-wrap"]',
   CHAT_MESSAGE_REPLY: '[name="message-reply"]',
+  CHAT_MESSAGE_REPLY_TEXT: "//Group/Text",
   CHAT_MESSAGE_TEXT_GROUP: '[name="message-text"]',
   CHAT_MESSAGE_TEXT_VALUE: "//Text",
   CHAT_MESSAGE_TIME_AGO: '[name="time-ago"]',
@@ -21,8 +23,17 @@ const SELECTORS_WINDOWS = {
   CHAT_USER_IMAGE_WRAP: '[name="user-image-wrap"]',
   CHAT_USER_INDICATOR_OFFLINE: '[name="indicator-offline"]',
   CHAT_USER_INDICATOR_ONLINE: '[name="indicator-online"]',
+  CONTEXT_MENU: '[name="Context Menu"]',
+  CONTEXT_MENU_OPTION: '[name="Context Item"]',
   INPUT_GROUP: '[name="input-group"]',
   INPUT_TEXT: "//Edit",
+  REPLY_POPUP_CLOSE_BUTTON: "//Button[1]",
+  REPLY_POPUP_HEADER: "//Text[1]/Text",
+  REPLY_POPUP_INDICATOR_OFFLINE: '[name="indicator-offline"]',
+  REPLY_POPUP_INDICATOR_ONLINE: '[name="indicator-online"]',
+  REPLY_POPUP_TEXT_TO_REPLY: "//Text[2]",
+  REPLY_POPUP_USER_IMAGE: '[name="User Image"]',
+  REPLY_POPUP_USER_IMAGE_WRAP: '[name="user-image-wrap"]',
   SEND_MESSAGE_BUTTON: '[name="send-message-button"]',
   TOOLTIP: '[name="tooltip"]',
   TOOLTIP_TEXT: "//Group/Text",
@@ -46,6 +57,8 @@ const SELECTORS_MACOS = {
   CHAT_MESSAGE_GROUP_SENT: "~message-group",
   CHAT_MESSAGE_GROUP_WRAP: "~message-group-wrap",
   CHAT_MESSAGE_REPLY: "~message-reply",
+  CHAT_MESSAGE_REPLY_TEXT:
+    "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText",
   CHAT_MESSAGE_TEXT_GROUP: "~message-text",
   CHAT_MESSAGE_TEXT_VALUE: "-ios class chain:**/XCUIElementTypeStaticText",
   CHAT_MESSAGE_TIME_AGO: "~time-ago",
@@ -54,8 +67,18 @@ const SELECTORS_MACOS = {
   CHAT_USER_IMAGE_WRAP: "~user-image-wrap",
   CHAT_USER_INDICATOR_OFFLINE: "~indicator-offline",
   CHAT_USER_INDICATOR_ONLINE: "~indicator-online",
+  CONTEXT_MENU: "~Context Menu",
+  CONTEXT_MENU_OPTION: "~Context Item",
   INPUT_GROUP: "~input-group",
   INPUT_TEXT: "-ios class chain:**/XCUIElementTypeTextView",
+  REPLY_POPUP_CLOSE_BUTTON: "-ios class chain:**/XCUIElementTypeButton[1]",
+  REPLY_POPUP_HEADER:
+    "-ios class chain:**/XCUIElementTypeStaticText[1]/XCUIElementTypeStaticText",
+  REPLY_POPUP_INDICATOR_OFFLINE: "~indicator-offline",
+  REPLY_POPUP_INDICATOR_ONLINE: "~indicator-online",
+  REPLY_POPUP_TEXT_TO_REPLY: "-ios class chain:**/XCUIElementTypeStaticText[2]",
+  REPLY_POPUP_USER_IMAGE: "~User Image",
+  REPLY_POPUP_USER_IMAGE_WRAP: "~user-image-wrap",
   SEND_MESSAGE_BUTTON: "~send-message-button",
   TOOLTIP: "~tooltip",
   TOOLTIP_TEXT:
@@ -107,6 +130,10 @@ class ChatScreen extends UplinkMainScreen {
     return $(SELECTORS.MESSAGE_GROUP).$(SELECTORS.CHAT_MESSAGE_REPLY);
   }
 
+  get chatMessageReplyText() {
+    return $(SELECTORS.CHAT_MESSAGE_REPLY).$(SELECTORS.CHAT_MESSAGE_REPLY_TEXT);
+  }
+
   get chatMessageTextValue() {
     return $$(SELECTORS.CHAT_MESSAGE_TEXT_GROUP).$(
       SELECTORS.CHAT_MESSAGE_TEXT_VALUE
@@ -149,6 +176,14 @@ class ChatScreen extends UplinkMainScreen {
       .$(SELECTORS.CHAT_USER_INDICATOR_ONLINE);
   }
 
+  get contextMenu() {
+    return $(SELECTORS.CONTEXT_MENU);
+  }
+
+  get contextMenuOption() {
+    return $$(SELECTORS.CONTEXT_MENU_OPTION);
+  }
+
   get inputGroup() {
     return $(SELECTORS.INPUT_GROUP);
   }
@@ -157,6 +192,28 @@ class ChatScreen extends UplinkMainScreen {
     return $(SELECTORS.CHAT_LAYOUT)
       .$(SELECTORS.INPUT_GROUP)
       .$(SELECTORS.INPUT_TEXT);
+  }
+
+  get replyPopUpCloseButton() {
+    return $(SELECTORS.CHAT_LAYOUT).$(SELECTORS.REPLY_POPUP_CLOSE_BUTTON);
+  }
+  get replyPopUpHeader() {
+    return $(SELECTORS.CHAT_LAYOUT).$(SELECTORS.REPLY_POPUP_CLOSE_BUTTON);
+  }
+  get replyPopUpIndicatorOffline() {
+    return $(SELECTORS.CHAT_LAYOUT).$(SELECTORS.REPLY_POPUP_CLOSE_BUTTON);
+  }
+  get replyPopUpIndicatorOnline() {
+    return $(SELECTORS.CHAT_LAYOUT).$(SELECTORS.REPLY_POPUP_CLOSE_BUTTON);
+  }
+  get replyPopUpTextToReply() {
+    return $(SELECTORS.CHAT_LAYOUT).$(SELECTORS.REPLY_POPUP_CLOSE_BUTTON);
+  }
+  get replyPopUpUserImage() {
+    return $(SELECTORS.CHAT_LAYOUT).$(SELECTORS.REPLY_POPUP_CLOSE_BUTTON);
+  }
+  get replyPopUpUserImageWrap() {
+    return $(SELECTORS.CHAT_LAYOUT).$(SELECTORS.REPLY_POPUP_CLOSE_BUTTON);
   }
 
   get sendMessageButton() {
@@ -283,6 +340,10 @@ class ChatScreen extends UplinkMainScreen {
     await this.uploadButton.click();
   }
 
+  async closeReplyModal() {
+    await this.replyPopUpCloseButton.click();
+  }
+
   // Message Group Wraps Methods
 
   async getLastGroupWrap() {
@@ -349,6 +410,21 @@ class ChatScreen extends UplinkMainScreen {
       .$(SELECTORS.CHAT_MESSAGE_TIME_AGO_TEXT)
       .getText();
     return timeAgoText;
+  }
+
+  async openContextMenuOnReceivedMessage() {
+    const messageToClick = await this.getLastMessageReceivedLocator();
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === "mac2") {
+      await rightClickOnMacOS(messageToClick);
+    } else if (currentDriver === "windows") {
+      await rightClickOnWindows(messageToClick);
+    }
+    await (await this.contextMenu).waitForDisplayed();
+  }
+
+  async selectContextOption(option: number) {
+    await this.contextMenuOption[option].click();
   }
 
   // Messages Sent Methods

--- a/tests/specs/reusable-accounts/01-chats-userA.spec.ts
+++ b/tests/specs/reusable-accounts/01-chats-userA.spec.ts
@@ -1,5 +1,4 @@
 import { loginWithTestUser } from "../../helpers/commands";
-import { faker } from "@faker-js/faker";
 import ChatScreen from "../../screenobjects/ChatScreen";
 import FriendsScreen from "../../screenobjects/FriendsScreen";
 import WelcomeScreen from "../../screenobjects/WelcomeScreen";
@@ -58,37 +57,6 @@ describe("Two users at the same time - Chat User A", async () => {
     expect(onlineIndicator).toExist();
   });
 
-  it("Receive Reply - Validate reply message group reply and message replied", async () => {
-    // Validate message replied appears smaller above your reply
-    expect(await ChatScreen.chatMessageReply).toBeDisplayed();
-    expect(await ChatScreen.chatMessageReplyText).toHaveTextContaining(
-      "testing..."
-    );
-
-    // Validate reply message sent appears as last message
-    const textFromMessage = await ChatScreen.getLastMessageReceivedText();
-    expect(textFromMessage).toEqual("this is a reply");
-  });
-
-  it("Receive Reply - Validate reply message group contains timestamp", async () => {
-    //Timestamp from last message sent should be displayed
-    const timeAgo = await ChatScreen.getLastMessageReceivedTimeAgo();
-    expect(timeAgo).toHaveTextContaining(
-      /^(?:\d{1,2}\s+(?:second|minute)s?\s+ago|now)$/
-    );
-    expect(timeAgo).toHaveTextContaining("ChatUserB");
-  });
-
-  it("Receive Reply - Validate reply message group contains user image and online indicator", async () => {
-    //Your user image should be displayed next to the message
-    const userImage = await ChatScreen.getLastGroupWrapImage();
-    expect(userImage).toExist();
-
-    //Online indicator of your user should be displayed next to the image
-    const onlineIndicator = await ChatScreen.getLastGroupWrapOnline();
-    expect(onlineIndicator).toExist();
-  });
-
   it("Validate Chat Screen tooltips are displayed", async () => {
     // Validate Favorites button tooltip
     await ChatScreen.hoverOnFavoritesButton();
@@ -134,6 +102,40 @@ describe("Two users at the same time - Chat User A", async () => {
     expect(await ChatScreen.topbarUserImage).toBeDisplayed();
     expect(await ChatScreen.topbarUserName).toHaveTextContaining("ChatUserB");
     expect(await ChatScreen.topbarIndicatorOnline).toBeDisplayed();
+  });
+
+  it("Receive Reply - Validate reply message group reply and message replied", async () => {
+    // Wait until reply is received
+    await ChatScreen.waitUntilReplyIsReceived();
+
+    // Validate message replied appears smaller above your reply
+    const replyReceived = await ChatScreen.getLastReplyReceived();
+    const replyReceivedText = await ChatScreen.getLastReplyReceivedText();
+    expect(replyReceived).toBeDisplayed();
+    expect(replyReceivedText).toHaveTextContaining("testing...");
+
+    // Validate reply message sent appears as last message
+    const textFromMessage = await ChatScreen.getLastMessageReceivedText();
+    expect(textFromMessage).toEqual("this is a reply");
+  });
+
+  it("Receive Reply - Validate reply message group contains timestamp", async () => {
+    //Timestamp from last message sent should be displayed
+    const timeAgo = await ChatScreen.getLastMessageReceivedTimeAgo();
+    expect(timeAgo).toHaveTextContaining(
+      /^(?:\d{1,2}\s+(?:second|minute)s?\s+ago|now)$/
+    );
+    expect(timeAgo).toHaveTextContaining("ChatUserB");
+  });
+
+  it("Receive Reply - Validate reply message group contains user image and online indicator", async () => {
+    //Your user image should be displayed next to the message
+    const userImage = await ChatScreen.getLastGroupWrapImage();
+    expect(userImage).toExist();
+
+    //Online indicator of your user should be displayed next to the image
+    const onlineIndicator = await ChatScreen.getLastGroupWrapOnline();
+    expect(onlineIndicator).toExist();
   });
 
   after(async () => {

--- a/tests/specs/reusable-accounts/01-chats-userA.spec.ts
+++ b/tests/specs/reusable-accounts/01-chats-userA.spec.ts
@@ -104,10 +104,12 @@ describe("Two users at the same time - Chat User A", async () => {
     expect(await ChatScreen.topbarIndicatorOnline).toBeDisplayed();
   });
 
-  it("Receive Reply - Validate reply message group reply and message replied", async () => {
+  it("Receive Reply - Validate reply message is received from remote user", async () => {
     // Wait until reply is received
     await ChatScreen.waitUntilReplyIsReceived();
+  });
 
+  it("Receive Reply - Validate reply message contents", async () => {
     // Validate message replied appears smaller above your reply
     const replyReceived = await ChatScreen.getLastReplyReceived();
     const replyReceivedText = await ChatScreen.getLastReplyReceivedText();

--- a/tests/specs/reusable-accounts/01-chats-userA.spec.ts
+++ b/tests/specs/reusable-accounts/01-chats-userA.spec.ts
@@ -106,7 +106,9 @@ describe("Two users at the same time - Chat User A", async () => {
 
   it("Receive Reply - Validate reply message is received from remote user", async () => {
     // Wait until reply is received
-    await ChatScreen.waitUntilReplyIsReceived();
+    await (
+      await ChatScreen.chatMessageReply
+    ).waitForDisplayed({ timeout: 180000 });
   });
 
   it("Receive Reply - Validate reply message contents", async () => {

--- a/tests/specs/reusable-accounts/01-chats-userA.spec.ts
+++ b/tests/specs/reusable-accounts/01-chats-userA.spec.ts
@@ -58,6 +58,37 @@ describe("Two users at the same time - Chat User A", async () => {
     expect(onlineIndicator).toExist();
   });
 
+  it("Receive Reply - Validate reply message group reply and message replied", async () => {
+    // Validate message replied appears smaller above your reply
+    expect(await ChatScreen.chatMessageReply).toBeDisplayed();
+    expect(await ChatScreen.chatMessageReplyText).toHaveTextContaining(
+      "testing..."
+    );
+
+    // Validate reply message sent appears as last message
+    const textFromMessage = await ChatScreen.getLastMessageReceivedText();
+    expect(textFromMessage).toEqual("this is a reply");
+  });
+
+  it("Receive Reply - Validate reply message group contains timestamp", async () => {
+    //Timestamp from last message sent should be displayed
+    const timeAgo = await ChatScreen.getLastMessageReceivedTimeAgo();
+    expect(timeAgo).toHaveTextContaining(
+      /^(?:\d{1,2}\s+(?:second|minute)s?\s+ago|now)$/
+    );
+    expect(timeAgo).toHaveTextContaining("ChatUserB");
+  });
+
+  it("Receive Reply - Validate reply message group contains user image and online indicator", async () => {
+    //Your user image should be displayed next to the message
+    const userImage = await ChatScreen.getLastGroupWrapImage();
+    expect(userImage).toExist();
+
+    //Online indicator of your user should be displayed next to the image
+    const onlineIndicator = await ChatScreen.getLastGroupWrapOnline();
+    expect(onlineIndicator).toExist();
+  });
+
   it("Validate Chat Screen tooltips are displayed", async () => {
     // Validate Favorites button tooltip
     await ChatScreen.hoverOnFavoritesButton();
@@ -103,8 +134,10 @@ describe("Two users at the same time - Chat User A", async () => {
     expect(await ChatScreen.topbarUserImage).toBeDisplayed();
     expect(await ChatScreen.topbarUserName).toHaveTextContaining("ChatUserB");
     expect(await ChatScreen.topbarIndicatorOnline).toBeDisplayed();
+  });
 
-    // At the end of testing, wait for 30 seconds before ending session
+  after(async () => {
+    // Pause for 30 seconds before finishing execution
     await browser.pause(30000);
   });
 });

--- a/tests/specs/reusable-accounts/02-chats-userB.spec.ts
+++ b/tests/specs/reusable-accounts/02-chats-userB.spec.ts
@@ -1,5 +1,4 @@
 import { loginWithTestUser } from "../../helpers/commands";
-import { faker } from "@faker-js/faker";
 import ChatScreen from "../../screenobjects/ChatScreen";
 import FriendsScreen from "../../screenobjects/FriendsScreen";
 import WelcomeScreen from "../../screenobjects/WelcomeScreen";
@@ -71,7 +70,7 @@ describe("Two users at the same time - Chat User B", async () => {
     expect(await ChatScreen.replyPopUpUserImage).toBeDisplayed();
 
     await ChatScreen.closeReplyModal();
-    await ChatScreen.replyPopUpHeader.waitForDisplayed({ reverse: true });
+    await ChatScreen.waitForReplyModalToNotExist();
   });
 
   it("Reply - Reply to a message", async () => {
@@ -82,15 +81,15 @@ describe("Two users at the same time - Chat User B", async () => {
     await (await ChatScreen.replyPopUpHeader).waitForDisplayed();
     await ChatScreen.typeMessageOnInput("this is a reply");
     await ChatScreen.clickOnSendMessage();
-    await ChatScreen.replyPopUpHeader.waitForDisplayed({ reverse: true });
+    await ChatScreen.waitForReplyModalToNotExist();
   });
 
   it("Send Reply - Validate reply message group reply and message replied", async () => {
     // Validate message replied appears smaller above your reply
-    expect(await ChatScreen.chatMessageReply).toBeDisplayed();
-    expect(await ChatScreen.chatMessageReplyText).toHaveTextContaining(
-      "testing..."
-    );
+    const replySent = await ChatScreen.getLastReplySent();
+    const replySentText = await ChatScreen.getLastReplySentText();
+    expect(replySent).toBeDisplayed();
+    expect(replySentText).toHaveTextContaining("testing...");
 
     // Validate reply message sent appears as last message
     const textFromMessage = await ChatScreen.getLastMessageSentText();

--- a/tests/specs/reusable-accounts/02-chats-userB.spec.ts
+++ b/tests/specs/reusable-accounts/02-chats-userB.spec.ts
@@ -53,7 +53,70 @@ describe("Two users at the same time - Chat User B", async () => {
       /^(?:\d{1,2}\s+(?:second|minute)s?\s+ago|now)$/
     );
     expect(timeAgo).toHaveTextContaining("ChatUserA");
+  });
 
+  it("Reply popup - Validate contents and close it", async () => {
+    await ChatScreen.openContextMenuOnReceivedMessage();
+    await ChatScreen.selectContextOption(0);
+
+    // Validate contents of Reply Pop Up
+    expect(await ChatScreen.replyPopUpCloseButton).toBeDisplayed();
+    expect(await ChatScreen.replyPopUpHeader).toHaveTextContaining(
+      "REPLYING TO:"
+    );
+    expect(await ChatScreen.replyPopUpIndicatorOnline).toBeDisplayed();
+    expect(await ChatScreen.replyPopUpTextToReply).toHaveTextContaining(
+      "testing..."
+    );
+    expect(await ChatScreen.replyPopUpUserImage).toBeDisplayed();
+
+    await ChatScreen.closeReplyModal();
+    await ChatScreen.replyPopUpHeader.waitForDisplayed({ reverse: true });
+  });
+
+  it("Reply - Reply to a message", async () => {
+    await ChatScreen.openContextMenuOnReceivedMessage();
+    await ChatScreen.selectContextOption(0);
+
+    // Type a reply and sent it
+    await (await ChatScreen.replyPopUpHeader).waitForDisplayed();
+    await ChatScreen.typeMessageOnInput("this is a reply");
+    await ChatScreen.clickOnSendMessage();
+    await ChatScreen.replyPopUpHeader.waitForDisplayed({ reverse: true });
+  });
+
+  it("Send Reply - Validate reply message group reply and message replied", async () => {
+    // Validate message replied appears smaller above your reply
+    expect(await ChatScreen.chatMessageReply).toBeDisplayed();
+    expect(await ChatScreen.chatMessageReplyText).toHaveTextContaining(
+      "testing..."
+    );
+
+    // Validate reply message sent appears as last message
+    const textFromMessage = await ChatScreen.getLastMessageSentText();
+    expect(textFromMessage).toEqual("this is a reply");
+  });
+
+  it("Send Reply - Validate reply message group contains timestamp", async () => {
+    //Timestamp from last message sent should be displayed
+    const timeAgo = await ChatScreen.getLastMessageSentTimeAgo();
+    expect(timeAgo).toHaveTextContaining(
+      /^(?:\d{1,2}\s+(?:second|minute)s?\s+ago|now)$/
+    );
+    expect(timeAgo).toHaveTextContaining("ChatUserB");
+  });
+
+  it("Send Reply - Validate reply message group contains user image and online indicator", async () => {
+    //Your user image should be displayed next to the message
+    const userImage = await ChatScreen.getLastGroupWrapImage();
+    expect(userImage).toExist();
+
+    //Online indicator of your user should be displayed next to the image
+    const onlineIndicator = await ChatScreen.getLastGroupWrapOnline();
+    expect(onlineIndicator).toExist();
+  });
+
+  after(async () => {
     // Pause for 30 seconds before finishing execution
     await browser.pause(30000);
   });


### PR DESCRIPTION
### What this PR does 📖

- Adding UI tests for testing reply popup, and sending/receiving a reply
- Adding UI locators and methods into chats screenobject required for these validations
- Draft PR for now

### Which issue(s) this PR fixes 🔨

- Resolve #144 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
