### PR TITLE
chore(appium): workaround to fix makefile before building app

### DIFF
--- a/.github/workflows/build-cron-job.yml
+++ b/.github/workflows/build-cron-job.yml
@@ -59,6 +59,10 @@ jobs:
         with:
           repo-token: ${{env.GITHUB_TOKEN}}
 
+      - name: Patch Makefile to remove --production-mode flag 🌐
+        run: |
+          perl -i -pe 's/--production-mode//g' Makefile
+
       - name: Run cargo update 🌐
         run: cargo update
 


### PR DESCRIPTION
### What this PR does 📖

- Workaround to patch Makefile to remove --production-mode before building the app because this was triggering issues n MacOS. There is current branch where a fix for this will be placed on Uplink

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
