### PR TITLE
test(add): input with empty and max chars messages and coming soon tooltips

### DIFF
--- a/tests/screenobjects/ChatScreen.ts
+++ b/tests/screenobjects/ChatScreen.ts
@@ -1,3 +1,4 @@
+import { faker } from "@faker-js/faker";
 import { rightClickOnMacOS, rightClickOnWindows } from "../helpers/commands";
 import UplinkMainScreen from "./UplinkMainScreen";
 
@@ -334,12 +335,37 @@ class ChatScreen extends UplinkMainScreen {
     await (await this.inputText).clearValue();
   }
 
+  async clickOnInputBar() {
+    await (await this.inputText).click();
+  }
+
   async clickOnSendMessage() {
     await this.sendMessageButton.click();
   }
 
   async clickOnUploadFile() {
     await this.uploadButton.click();
+  }
+
+  async generateRandomText() {
+    // Get a random word of 9 chars and add it a space
+    const wordToRepeat = faker.lorem.word(9) + " ";
+    // Then repeat the same word for 102 times (1020 chars)
+    let longParagraph = wordToRepeat.repeat(102);
+    // Now, add 4 more chars, to have 1024 chars
+    longParagraph += "abcd";
+    return longParagraph;
+  }
+
+  async pressEnterKeyOnInputBar() {
+    const currentDriver = await this.getCurrentDriver();
+    let enterValue;
+    currentDriver === "windows" ? (enterValue = "\uE007") : (enterValue = "\n");
+    await (await this.inputText).setValue(enterValue);
+  }
+
+  async typeMessageOnInput(text: string) {
+    await (await this.inputText).setValue(text);
   }
 
   async typeOnEditMessageInput(editedMessage: string) {
@@ -546,6 +572,10 @@ class ChatScreen extends UplinkMainScreen {
 
   // Hovering methods
 
+  async hoverOnCallButton() {
+    await this.hoverOnElement(await this.topbarCall);
+  }
+
   async hoverOnFavoritesButton() {
     await this.hoverOnElement(await this.topbarAddToFavorites);
   }
@@ -558,8 +588,8 @@ class ChatScreen extends UplinkMainScreen {
     await this.hoverOnElement(await this.uploadButton);
   }
 
-  async typeMessageOnInput(text: string) {
-    await (await this.inputText).setValue(text);
+  async hoverOnVideocallButton() {
+    await this.hoverOnElement(await this.topbarVideocall);
   }
 
   // Reply Modal methods

--- a/tests/specs/reusable-accounts/01-chats-userA.spec.ts
+++ b/tests/specs/reusable-accounts/01-chats-userA.spec.ts
@@ -57,6 +57,22 @@ describe("Two users at the same time - Chat User A", async () => {
     expect(onlineIndicator).toExist();
   });
 
+  it("Validate Chat Screen tooltips for Call and Videocall display Coming soon", async () => {
+    // Validate Call button tooltip contains "Coming soon"
+    await ChatScreen.hoverOnCallButton();
+    expect(await ChatScreen.topbarCallTooltip).toBeDisplayed();
+    expect(await ChatScreen.topbarCallTooltipText).toHaveTextContaining(
+      "Coming soon"
+    );
+
+    // Validate Videocall button tooltip contains "Coming soon"
+    await ChatScreen.hoverOnVideocallButton();
+    expect(await ChatScreen.topbarVideocallTooltip).toBeDisplayed();
+    expect(await ChatScreen.topbarVideocallTooltipText).toHaveTextContaining(
+      "Coming soon"
+    );
+  });
+
   it("Validate Chat Screen tooltips are displayed", async () => {
     // Validate Favorites button tooltip
     await ChatScreen.hoverOnFavoritesButton();
@@ -170,6 +186,37 @@ describe("Two users at the same time - Chat User A", async () => {
     // Validate message edited contents is shown on Chat Screen
     const textFromMessage = await ChatScreen.getLastMessageSentText();
     expect(textFromMessage).toEqual("message edited...");
+  });
+
+  it("Context Menu - User cannot send empty messages", async () => {
+    // Ensure that input bar is empty and click on send message button
+    await ChatScreen.clearInputBar();
+    await ChatScreen.clearInputBar();
+    await ChatScreen.clickOnInputBar();
+    await ChatScreen.clickOnSendMessage();
+
+    // Ensure that input bar is empty and press Enter Key
+    await ChatScreen.clearInputBar();
+    await ChatScreen.clickOnInputBar();
+    await ChatScreen.pressEnterKeyOnInputBar();
+
+    // Validate latest message sent displayed on Chat Conversation is still "message edited..."
+    const latestMessage = await ChatScreen.getLastMessageSentText();
+    expect(latestMessage).toEqual("message edited...");
+  });
+
+  it("Context Menu - User can type up to 1024 chars on input bar", async () => {
+    // Generate a random text with 1024 chars
+    const longText = await ChatScreen.generateRandomText();
+    // Type long text with 1024 chars on input bar and attempt to add 4 more chars (efgh)
+    await ChatScreen.typeMessageOnInput(longText + "efgh");
+
+    // Ensure that latest chars were not added to input bar, since the max number of chars has been reached
+    // Input bar text should be equal to long text with 1024 chars
+    await expect(ChatScreen.inputText).toHaveText(longText);
+
+    // Clear input bar to finish test
+    await ChatScreen.clearInputBar();
   });
 
   after(async () => {

--- a/tests/specs/reusable-accounts/02-chats-userB.spec.ts
+++ b/tests/specs/reusable-accounts/02-chats-userB.spec.ts
@@ -117,7 +117,7 @@ describe("Two users at the same time - Chat User B", async () => {
 
   it("Validate that second message was edited", async () => {
     // Validate that last message is "message edited..."
-    await ChatScreen.waitForReceivingMessage("message edited...", 180000);
+    await ChatScreen.waitForReceivingMessage("message edited...", 240000);
   });
 
   it("Validate that only deleted message is no longer in conversation", async () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Adding test for coming soon tooltips on Call and Videocall buttons on Chat Screen
- Adding test to validate that empty messages cannot be sent on Chat Screen
- Adding test for maximum number of characters on input bar for Chat Screen
- Increasing timeout to wait for edited message on Chat User B (sometimes this test fails)

### Which issue(s) this PR fixes 🔨

- Resolve #140 #190 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
