### PR TITLE
chore(appium): add recursive argument to mkdir for screenshots folder…

### DIFF
--- a/config/wdio.mac.app.conf.ts
+++ b/config/wdio.mac.app.conf.ts
@@ -31,7 +31,7 @@ config.afterTest = async function (test, describe, { error }) {
   if (error) {
     let imageFile = await driver.takeScreenshot();
     let imageFolder = join(process.cwd(), "./test-results/macos", test.parent);
-    await fsp.mkdir(imageFolder);
+    await fsp.mkdir(imageFolder, {recursive: true});
     await fsp.writeFile(
       imageFolder + "/" + test.title + " - Failed.png",
       imageFile,

--- a/config/wdio.mac.chatA.conf.ts
+++ b/config/wdio.mac.chatA.conf.ts
@@ -43,7 +43,7 @@ config.afterTest = async function (test, describe, { error }) {
   if (error) {
     let imageFile = await driver.takeScreenshot();
     let imageFolder = join(process.cwd(), "./test-results/macos", test.parent);
-    await fsp.mkdir(imageFolder);
+    await fsp.mkdir(imageFolder, {recursive: true});
     await fsp.writeFile(
       imageFolder + "/" + test.title + " - Failed.png",
       imageFile,

--- a/config/wdio.mac.chatB.conf.ts
+++ b/config/wdio.mac.chatB.conf.ts
@@ -43,7 +43,7 @@ config.afterTest = async function (test, describe, { error }) {
   if (error) {
     let imageFile = await driver.takeScreenshot();
     let imageFolder = join(process.cwd(), "./test-results/macos", test.parent);
-    await fsp.mkdir(imageFolder);
+    await fsp.mkdir(imageFolder, {recursive: true});
     await fsp.writeFile(
       imageFolder + "/" + test.title + " - Failed.png",
       imageFile,

--- a/config/wdio.mac.ci.conf.ts
+++ b/config/wdio.mac.ci.conf.ts
@@ -31,7 +31,7 @@ config.afterTest = async function (test, describe, { error }) {
   if (error) {
     let imageFile = await driver.takeScreenshot();
     let imageFolder = join(process.cwd(), "./test-results/macos", test.parent);
-    await fsp.mkdir(imageFolder);
+    await fsp.mkdir(imageFolder, {recursive: true});
     await fsp.writeFile(
       imageFolder + "/" + test.title + " - Failed.png",
       imageFile,

--- a/config/wdio.windows.app.conf.ts
+++ b/config/wdio.windows.app.conf.ts
@@ -32,7 +32,7 @@ config.afterTest = async function (test, describe, { error }) {
   if (error) {
     let imageFile = await driver.takeScreenshot();
     let imageFolder = join(process.cwd(), "./test-results/windows", test.parent);
-    await fsp.mkdir(imageFolder);
+    await fsp.mkdir(imageFolder, {recursive: true});
     await fsp.writeFile(
       imageFolder + "/" + test.title + " - Failed.png",
       imageFile,

--- a/config/wdio.windows.chatA.conf.ts
+++ b/config/wdio.windows.chatA.conf.ts
@@ -43,7 +43,7 @@ config.afterTest = async function (test, describe, { error }) {
   if (error) {
     let imageFile = await driver.takeScreenshot();
     let imageFolder = join(process.cwd(), "./test-results/windows", test.parent);
-    await fsp.mkdir(imageFolder);
+    await fsp.mkdir(imageFolder, {recursive: true});
     await fsp.writeFile(
       imageFolder + "/" + test.title + " - Failed.png",
       imageFile,

--- a/config/wdio.windows.ci.conf.ts
+++ b/config/wdio.windows.ci.conf.ts
@@ -40,7 +40,7 @@ config.afterTest = async function (test, describe, { error }) {
   if (error) {
     let imageFile = await driver.takeScreenshot();
     let imageFolder = join(process.cwd(), "./test-results/windows", test.parent);
-    await fsp.mkdir(imageFolder);
+    await fsp.mkdir(imageFolder, {recursive: true});
     await fsp.writeFile(
       imageFolder + "/" + test.title + " - Failed.png",
       imageFile,

--- a/tests/helpers/commands.ts
+++ b/tests/helpers/commands.ts
@@ -20,7 +20,7 @@ export async function deleteCache() {
 export async function grabCacheFolder(username: string) {
   const source = homedir() + "/.uplink";
   const target = "./tests/fixtures/users/" + username;
-  await fsp.mkdir(target);
+  await fsp.mkdir(target, { recursive: true });
   try {
     await fsp.cp(source, target, { recursive: true });
     console.log("Copied user cache successfully");


### PR DESCRIPTION
### What this PR does 📖

- Screenshots folder creation during job running started to fail after updating to latest webdriverio version, since mkdir command needs the argument recursive: true to create the folder structure for screenshots.
- Updating all config files with this steup

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
