### PR TITLE
test(update): skip friends tests causing failures on CI

### DIFF
--- a/tests/suites/02-UplinkFriends.ts
+++ b/tests/suites/02-UplinkFriends.ts
@@ -1,6 +1,7 @@
 import friends from "../specs/04-friends.spec";
 
 // Note: The following test suite is not running for now on Windows CI due to appium issues that need investigation
-describe("Uplink UI Automated Tests with Reusable Account", function () {
+// This test spec causes random failures on CI that needs to be debugged so I am skipping this for now
+xdescribe("Uplink UI Automated Tests with Reusable Account", function () {
   describe("Friends Screen Tests", friends.bind(this));
 });


### PR DESCRIPTION
### What this PR does 📖

- Skipping 02-UplinkFriends.ts test suite since its causing failures on CI. Also, the plan is to move this to the Chat runners so it can be tested with accounts created during workflow instead of using a repo account

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
