### PR TITLE
chore(appium): stop autocorrect from macos executor

### DIFF
--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -188,6 +188,13 @@ jobs:
         run: ${{ matrix.appium-driver }}
 
       - if: matrix.os == 'macos-latest'
+        name: Update MacOS runner to not autocorrect text
+        run: |
+          defaults write -g NSAutomaticCapitalizationEnabled -bool false
+          defaults write -g NSAutomaticPeriodSubstitutionEnabled -bool false
+          defaults write -g NSAutomaticSpellingCorrectionEnabled -bool false
+
+      - if: matrix.os == 'macos-latest'
         name: Delete Cache Folder if exists - Mac
         run: rm -rf ~/.uplink
 
@@ -305,6 +312,12 @@ jobs:
           unzip Uplink-Mac-Universal.zip
           cp -r ./Uplink.app /Applications/
           sudo xattr -r -d com.apple.quarantine /Applications/Uplink.app
+
+      - name: Update MacOS runner to not autocorrect text
+        run: |
+          defaults write -g NSAutomaticCapitalizationEnabled -bool false
+          defaults write -g NSAutomaticPeriodSubstitutionEnabled -bool false
+          defaults write -g NSAutomaticSpellingCorrectionEnabled -bool false
 
       - name: Install and Run Appium Server 💻
         run: |


### PR DESCRIPTION
### What this PR does 📖

- Disable autocorrect from MacOS runners executing tests to avoid issues like this: 
![image](https://github.com/Satellite-im/testing-uplink/assets/35935591/80d31642-3a9a-4dfc-82a0-4c640f011982)


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
