### PR TITLE
test(update): add more wait for start on windows tests

### DIFF
--- a/config/wdio.windows.ci.conf.ts
+++ b/config/wdio.windows.ci.conf.ts
@@ -63,7 +63,7 @@ exports.config = {
           "appium:deviceName": "WindowsPC",
           "appium:automationName": "windows",
           "appium:app": join(process.cwd(), "\\apps\\uplink.exe"),
-          "ms:waitForAppLaunch": 30,
+          "ms:waitForAppLaunch": 50,
           "appium:prerun": {
             command: 'If (Test-Path $home/.uplink/.user) {Remove-Item -Recurse -Force $home/.uplink/.user} Else { Break }',
           },  

--- a/config/wdio.windows.multiremote.conf.ts
+++ b/config/wdio.windows.multiremote.conf.ts
@@ -63,7 +63,7 @@ exports.config = {
           "appium:app": join(process.cwd(), "\\apps\\uplink.exe"),
           "appium:systemPort": 4725,
           "appium:createSessionTimeout": 40000,
-          "ms:waitForAppLaunch": 10,
+          "ms:waitForAppLaunch": 50,
           "appium:appArguments": "--path " + join(process.cwd(), "\\apps\\ChatUserA"),
         }
       },
@@ -75,7 +75,7 @@ exports.config = {
           "appium:app": join(process.cwd(), "\\apps\\uplink2.exe"),
           "appium:systemPort": 4726,
           "appium:createSessionTimeout": 40000,
-          "ms:waitForAppLaunch": 10,
+          "ms:waitForAppLaunch": 50,
           "appium:appArguments": "--path " + join(process.cwd(), "\\apps\\ChatUserB"), 
         }
       },

--- a/tests/screenobjects/files/FilesScreen.ts
+++ b/tests/screenobjects/files/FilesScreen.ts
@@ -270,7 +270,7 @@ export default class FilesScreen extends UplinkMainScreen {
       await this.inputFolderFileName.setValue(name + "\uE007");
     }
     const newFolder = await this.getLocatorOfFolderFile(name);
-    await this.instance.$(newFolder).waitForExist();
+    await this.instance.$(newFolder).waitForExist({ timeout: 15000 });
   }
 
   async downloadFile(filename: string) {


### PR DESCRIPTION
### What this PR does 📖

- Adding more timeout wait on wait for app launch for windows config files
- Adding more timeout to wait for folder to be created on tests

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
