### PR TITLE
update(screenobject): trying waiting for pending friends button to avoid issue

### DIFF
--- a/tests/screenobjects/friends/FriendsScreen.ts
+++ b/tests/screenobjects/friends/FriendsScreen.ts
@@ -541,6 +541,7 @@ export default class FriendsScreen extends UplinkMainScreen {
   }
 
   async goToPendingFriendsList() {
+    await this.pendingFriendsButton.waitForExist();
     await this.pendingFriendsButton.click();
   }
 


### PR DESCRIPTION
### What this PR does 📖

- To avoid this issue when clicking on pending friends, I am adding a line to ensure that button exists before clicking on it. This errors is randomly happening on quick profile tests for windows

![image](https://github.com/Satellite-im/testing-uplink/assets/35935591/6b2a749b-1bb5-433b-9318-71ac1f87eca3)


### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
