### PR TITLE
chore(appium): remove cargo update from GH build workflow

### DIFF
--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -45,9 +45,6 @@ jobs:
         run: |
           rustup target add x86_64-apple-darwin aarch64-apple-darwin
 
-      - name: Run cargo update 🌐
-        run: cargo update
-
       - name: Build executable 🖥️
         run: make dmg
         continue-on-error: true
@@ -103,9 +100,6 @@ jobs:
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{env.GITHUB_TOKEN}}
-
-      - name: Run cargo update 🌐
-        run: cargo update
 
       - name: Build executable 🖥️
         run: cargo build --release --package uplink -F production_mode


### PR DESCRIPTION
### What this PR does 📖

- Removing cargo update step from GH workflow on build job to avoid issues presented for not relying on cargo.lock versions

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
