### PR TITLE
test(add): attempting to rename files or folders to existing names

### DIFF
--- a/tests/screenobjects/UplinkMainScreen.ts
+++ b/tests/screenobjects/UplinkMainScreen.ts
@@ -40,6 +40,8 @@ const SELECTORS_WINDOWS = {
   SIDEBAR_SEARCH: '[name="sidebar-search"]',
   SKELETAL_USER: '[name="skeletal-user"]',
   TOAST_NOTIFICATION: '[name="Toast Notification"]',
+  TOAST_NOTIFICATION_CLOSE: '[name="close-toast"]',
+  TOAST_NOTIFICATION_TEXT: '[name="toast-content"]',
   TOOLTIP: '[name="tooltip"]',
   TOOLTIP_TEXT: "//Group/Text",
   UPDATE_AVAILABLE: '[name="update-available"]',
@@ -83,6 +85,8 @@ const SELECTORS_MACOS = {
   SIDEBAR_SEARCH: "~sidebar-search",
   SKELETAL_USER: "~skeletal-user",
   TOAST_NOTIFICATION: "~Toast Notification",
+  TOAST_NOTIFICATION_CLOSE: "~close-toast",
+  TOAST_NOTIFICATION_TEXT: "~toast-content",
   TOOLTIP: "~tooltip",
   TOOLTIP_TEXT:
     "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText",
@@ -290,6 +294,22 @@ export default class UplinkMainScreen extends AppScreen {
     return this.instance.$$(SELECTORS.TOAST_NOTIFICATION);
   }
 
+  get toastNotification() {
+    return this.instance.$(SELECTORS.TOAST_NOTIFICATION);
+  }
+
+  get toastNotificationClose() {
+    return this.instance
+      .$(SELECTORS.TOAST_NOTIFICATION)
+      .$(SELECTORS.TOAST_NOTIFICATION_CLOSE);
+  }
+
+  get toastNotificationText() {
+    return this.instance
+      .$(SELECTORS.TOAST_NOTIFICATION)
+      .$(SELECTORS.TOAST_NOTIFICATION_TEXT);
+  }
+
   get updateAvailable() {
     return this.instance.$(SELECTORS.UPDATE_AVAILABLE);
   }
@@ -310,6 +330,23 @@ export default class UplinkMainScreen extends AppScreen {
 
   get window() {
     return this.instance.$(SELECTORS.WINDOW);
+  }
+
+  // Toast Notifications methods
+
+  async closeToastNotification() {
+    await this.toastNotificationClose.click();
+  }
+
+  async getToastNotificationText() {
+    const toastText = await this.toastNotificationText.getText();
+    return toastText;
+  }
+
+  async waitUntilNotificationIsClosed() {
+    await this.toastNotification.waitForDisplayed({
+      reverse: true,
+    });
   }
 
   // Clicking on common elements methods

--- a/tests/screenobjects/files/FilesScreen.ts
+++ b/tests/screenobjects/files/FilesScreen.ts
@@ -252,6 +252,10 @@ export default class FilesScreen extends UplinkMainScreen {
     return this.instance.$(SELECTORS.UPLOAD_FILE_INDICATOR_PROGRESS);
   }
 
+  async clickOnCreateFolder() {
+    await this.addFolderButton.click();
+  }
+
   async clickOnFileOrFolder(locator: string) {
     const element = await this.getLocatorOfFolderFile(locator);
     await this.instance.$(element).click();
@@ -281,7 +285,7 @@ export default class FilesScreen extends UplinkMainScreen {
 
   async createFolder(name: string) {
     const currentDriver = await this.getCurrentDriver();
-    await this.addFolderButton.click();
+    await this.clickOnCreateFolder();
     if (currentDriver === "mac2") {
       await this.inputFolderFileName.setValue(name + "\n");
     } else if (currentDriver === "windows") {
@@ -289,6 +293,15 @@ export default class FilesScreen extends UplinkMainScreen {
     }
     const newFolder = await this.getLocatorOfFolderFile(name);
     await this.instance.$(newFolder).waitForExist({ timeout: 15000 });
+  }
+
+  async typeOnFileFolderNameInput(name: string) {
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === "mac2") {
+      await this.inputFolderFileName.setValue(name + "\n");
+    } else if (currentDriver === "windows") {
+      await this.inputFolderFileName.setValue(name + "\uE007");
+    }
   }
 
   async downloadFile(filename: string) {

--- a/tests/screenobjects/friends/FriendsScreen.ts
+++ b/tests/screenobjects/friends/FriendsScreen.ts
@@ -63,9 +63,6 @@ const SELECTORS_WINDOWS = {
   OUTGOING_REQUESTS_LIST_LABEL: '[name="outgoing-list-label"]',
   PENDING_FRIENDS_BUTTON: '[name="pending-friends-button"]',
   REMOVE_OR_DENY_FRIEND_BUTTON: '[name="Remove or Deny Friend"]',
-  TOAST_NOTIFICATION: '[name="Toast Notification"]',
-  TOAST_NOTIFICATION_CLOSE: '[name="close-toast"]',
-  TOAST_NOTIFICATION_TEXT: '[name="toast-content"]',
   TOOLTIP: '[name="tooltip"]',
   TOOLTIP_TEXT: "//Group/Text",
   TOPBAR: '[name="Topbar"]',
@@ -119,9 +116,6 @@ const SELECTORS_MACOS = {
   OUTGOING_REQUESTS_LIST_LABEL: "~outgoing-list-label",
   PENDING_FRIENDS_BUTTON: "~pending-friends-button",
   REMOVE_OR_DENY_FRIEND_BUTTON: "~Remove or Deny Friend",
-  TOAST_NOTIFICATION: "~Toast Notification",
-  TOAST_NOTIFICATION_CLOSE: "~close-toast",
-  TOAST_NOTIFICATION_TEXT: "~toast-content",
   TOOLTIP: "~tooltip",
   TOOLTIP_TEXT:
     "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText",
@@ -338,22 +332,6 @@ export default class FriendsScreen extends UplinkMainScreen {
     return this.instance.$(SELECTORS.REMOVE_OR_DENY_FRIEND_BUTTON);
   }
 
-  get toastNotification() {
-    return this.instance.$(SELECTORS.TOAST_NOTIFICATION);
-  }
-
-  get toastNotificationClose() {
-    return this.instance
-      .$(SELECTORS.TOAST_NOTIFICATION)
-      .$(SELECTORS.TOAST_NOTIFICATION_CLOSE);
-  }
-
-  get toastNotificationText() {
-    return this.instance
-      .$(SELECTORS.TOAST_NOTIFICATION)
-      .$(SELECTORS.TOAST_NOTIFICATION_TEXT);
-  }
-
   get topbar() {
     return this.instance.$(SELECTORS.TOPBAR);
   }
@@ -379,10 +357,6 @@ export default class FriendsScreen extends UplinkMainScreen {
 
   async clickOnCopyID() {
     await this.copyIdButton.click();
-  }
-
-  async closeToastNotification() {
-    await this.toastNotificationClose.click();
   }
 
   async deleteAddFriendInput() {
@@ -503,11 +477,6 @@ export default class FriendsScreen extends UplinkMainScreen {
       results.push(friendName);
     }
     return results;
-  }
-
-  async getToastNotificationText() {
-    const toastText = await this.toastNotificationText.getText();
-    return toastText;
   }
 
   async getUserFromAllFriendsList() {
@@ -694,12 +663,6 @@ export default class FriendsScreen extends UplinkMainScreen {
 
   async waitUntilFriendRequestIsReceived(timeout: number = 90000) {
     await this.acceptFriendRequestButton.waitForExist({ timeout: timeout });
-  }
-
-  async waitUntilNotificationIsClosed() {
-    await this.toastNotification.waitForDisplayed({
-      reverse: true,
-    });
   }
 
   async waitUntilUserAcceptedFriendRequest(timeout: number = 90000) {

--- a/tests/screenobjects/settings/SettingsProfileScreen.ts
+++ b/tests/screenobjects/settings/SettingsProfileScreen.ts
@@ -30,9 +30,6 @@ const SELECTORS_WINDOWS = {
   PROFILE_PICTURE_CLEAR: '[name="clear-avatar"]',
   STATUS_INPUT: '[name="status-input"]',
   STATUS_LABEL: '//Text[@Name="profile-status-label"]/Text',
-  TOAST_NOTIFICATION: '[name="Toast Notification"]',
-  TOAST_NOTIFICATION_CLOSE: '[name="close-toast"]',
-  TOAST_NOTIFICATION_TEXT: '[name="toast-content"]',
   TOOLTIP: '[name="tooltip"]',
   TOOLTIP_TEXT: "//Group/Text",
   USERNAME_INPUT: '[name="username-input"]',
@@ -62,9 +59,6 @@ const SELECTORS_MACOS = {
   PROFILE_PICTURE_CLEAR: "~clear-avatar",
   STATUS_INPUT: "~status-input",
   STATUS_LABEL: "-ios class chain:**/XCUIElementTypeStaticText[2]",
-  TOAST_NOTIFICATION: "~Toast Notification",
-  TOAST_NOTIFICATION_CLOSE: "~close-toast",
-  TOAST_NOTIFICATION_TEXT: "~toast-content",
   TOOLTIP: "~tooltip",
   TOOLTIP_TEXT:
     "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText",
@@ -168,22 +162,6 @@ export default class SettingsProfileScreen extends SettingsBaseScreen {
     return this.instance.$(SELECTORS.PROFILE_CONTENT).$(SELECTORS.STATUS_LABEL);
   }
 
-  get toastNotification() {
-    return this.instance.$(SELECTORS.TOAST_NOTIFICATION);
-  }
-
-  get toastNotificationClose() {
-    return this.instance
-      .$(SELECTORS.TOAST_NOTIFICATION)
-      .$(SELECTORS.TOAST_NOTIFICATION_CLOSE);
-  }
-
-  get toastNotificationText() {
-    return this.instance
-      .$(SELECTORS.TOAST_NOTIFICATION)
-      .$(SELECTORS.TOAST_NOTIFICATION_TEXT);
-  }
-
   get usernameInput() {
     return this.instance.$(SELECTORS.USERNAME_INPUT);
   }
@@ -240,10 +218,6 @@ export default class SettingsProfileScreen extends SettingsBaseScreen {
     await this.dismissButton.click();
   }
 
-  async closeToastNotification() {
-    await this.toastNotificationClose.click();
-  }
-
   async deleteStatus() {
     await this.statusInput.click();
     await this.statusInput.clearValue();
@@ -277,10 +251,6 @@ export default class SettingsProfileScreen extends SettingsBaseScreen {
 
   async getStatusInputValue() {
     return await this.statusInput.getText();
-  }
-
-  async getToastNotificationText() {
-    return await this.toastNotificationText.getText();
   }
 
   async hoverOnBanner() {
@@ -341,11 +311,5 @@ export default class SettingsProfileScreen extends SettingsBaseScreen {
 
     // Validate that profile banner is displayed on screen
     await this.profilePicture.waitForDisplayed();
-  }
-
-  async waitUntilNotificationIsClosed() {
-    await this.toastNotification.waitForExist({
-      reverse: true,
-    });
   }
 }

--- a/tests/specs/03-files.spec.ts
+++ b/tests/specs/03-files.spec.ts
@@ -206,4 +206,62 @@ export default async function files() {
       filesScreenFirstUser.filesInfoCurrentSizeValue
     ).toHaveTextContaining("13.2 MB");
   });
+
+  it("Files - File is renamed when uploading a file with existing file name", async () => {
+    // Upload app-macos.zip file again
+    await filesScreenFirstUser.uploadFile("./tests/fixtures/app-macos.zip");
+
+    // Wait until progress indicator disappears
+    await filesScreenFirstUser.uploadFileIndicatorProgress.waitForExist({
+      reverse: true,
+    });
+
+    // Once that progress indicator disappears, validate that file is loaded and is automatically renamed to avoid name conflicts
+    await filesScreenFirstUser.validateFileOrFolderExist("app-macos (1).zip");
+  });
+
+  it("Files - Attempt to rename a file with existing file name", async () => {
+    // Open context menu for app-macos (1).zip file and select the option "Rename"
+    await filesScreenFirstUser.openFilesContextMenu("app-macos (1).zip");
+    await filesScreenFirstUser.clickOnFilesRename();
+
+    // Attempt to set the new name for the file as app-macos.zip and wait for error toast notification to be closed
+    await filesScreenFirstUser.typeOnFileFolderNameInput("app-macos");
+    await filesScreenFirstUser.waitUntilNotificationIsClosed();
+
+    // Type the previous filename for app-macos (1) so it can keep the original name. Ensure that file still exists in Screen
+    await filesScreenFirstUser.typeOnFileFolderNameInput("app-macos (1)");
+    await filesScreenFirstUser.validateFileOrFolderExist("app-macos (1).zip");
+  });
+
+  it("Files - Attempt to create a folder with existing folder name", async () => {
+    // First, create a folder named "testfolder01"
+    await filesScreenFirstUser.createFolder("testfolder01");
+    await filesScreenFirstUser.validateFileOrFolderExist("testfolder01");
+
+    // Click on Create Folder and type the existing folder name "testfolder01"
+    await filesScreenFirstUser.clickOnCreateFolder();
+    await filesScreenFirstUser.typeOnFileFolderNameInput("testfolder01");
+
+    // Wait until error toast notification is closed and type a valid name for the new folder
+    await filesScreenFirstUser.waitUntilNotificationIsClosed();
+    await filesScreenFirstUser.typeOnFileFolderNameInput("testfolder02");
+
+    // Ensure that new folder was created with name "testfolder02"
+    await filesScreenFirstUser.validateFileOrFolderExist("testfolder02");
+  });
+
+  it("Files - Attempt to rename a folder with existing folder name", async () => {
+    // Open context menu for testfolder02 and select the first option "Rename"
+    await filesScreenFirstUser.openFilesContextMenu("testfolder02");
+    await filesScreenFirstUser.clickOnFolderRename();
+
+    // Attempt to change the name of testfolder02 to existing folder name testfolder01
+    await filesScreenFirstUser.typeOnFileFolderNameInput("testfolder01");
+
+    // Wait until error toast notification is closed and type the existing folder name for testfolder02
+    await filesScreenFirstUser.waitUntilNotificationIsClosed();
+    await filesScreenFirstUser.typeOnFileFolderNameInput("testfolder02");
+    await filesScreenFirstUser.validateFileOrFolderExist("testfolder02");
+  });
 }


### PR DESCRIPTION
### What this PR does 📖

- Moving toast notification UI locators and methods to Uplink Main Screen screenobject, so these are not repeated along other screenobject files
- Adding the following tests on Files Screen: 
- Upload a file with existing filename - File is automatically renamed to avoid conflicts
- Try to rename a file to existing filename
- Attempt to create a folder with existing folder name 
- Try to rename a folder to a existing folder name

### Which issue(s) this PR fixes 🔨

- Resolve #159 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
