### PR TITLE
chore(appium): update rust toolchain to 1.70.0

### DIFF
--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Rust 💿
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.68.2
+          toolchain: 1.70.0
           override: true
           components: rustfmt, clippy
 
@@ -92,7 +92,7 @@ jobs:
       - name: Install Rust 💿
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.68.2
+          toolchain: 1.70.0
           override: true
           components: rustfmt, clippy
 


### PR DESCRIPTION
### What this PR does 📖

- Updating rust toolchain to 1.70.0, due to the latest change applied today on Uplink this is required to build the app

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
