### PR TITLE
test(add): add tests for bolds markdowns and links

### DIFF
--- a/tests/screenobjects/chats/Messages.ts
+++ b/tests/screenobjects/chats/Messages.ts
@@ -23,6 +23,7 @@ const SELECTORS_WINDOWS = {
   CHAT_MESSAGE_FILE_NAME_TEXT: "//Text",
   CHAT_MESSAGE_LINK_EMBED: '[name="link-embed"]',
   CHAT_MESSAGE_LINK_EMBED_DETAILS: '[name="embed-details"]',
+  CHAT_MESSAGE_LINK_EMBED_DETAILS_TEXT: "//Text",
   CHAT_MESSAGE_LINK_EMBED_ICON: '[name="embed-icon"]',
   CHAT_MESSAGE_LINK_EMBED_TITLE: '[name="link-title"]',
   CHAT_MESSAGE_LOCAL: '[name="message-local"]',
@@ -45,6 +46,8 @@ const SELECTORS_MACOS = {
   CHAT_MESSAGE_FILE_NAME_TEXT: "-ios class chain:**/XCUIElementTypeStaticText",
   CHAT_MESSAGE_LINK_EMBED: "~link-embed",
   CHAT_MESSAGE_LINK_EMBED_DETAILS: "~embed-details",
+  CHAT_MESSAGE_LINK_EMBED_DETAILS_TEXT:
+    "-ios class chain:**/XCUIElementTypeStaticText",
   CHAT_MESSAGE_LINK_EMBED_ICON: "~embed-icon",
   CHAT_MESSAGE_LINK_EMBED_TITLE: "~link-title",
   CHAT_MESSAGE_LOCAL: "~message-local",
@@ -469,6 +472,73 @@ export default class Messages extends UplinkMainScreen {
       .$(SELECTORS.CHAT_MESSAGE_FILE_NAME)
       .$(SELECTORS.CHAT_MESSAGE_FILE_NAME_TEXT);
     return lastMessageFileName;
+  }
+
+  // Messages With Links Methods
+  async getLastMessageReceivedLinkEmbed() {
+    const lastMessage = await this.getLastMessageReceivedLocator();
+    const lastMessageLinkEmbed = await lastMessage.$(
+      SELECTORS.CHAT_MESSAGE_LINK_EMBED
+    );
+    return lastMessageLinkEmbed;
+  }
+
+  async getLastMessageReceivedLinkEmbedDetailsText() {
+    const linkEmbedLastMessage = await this.getLastMessageReceivedLinkEmbed();
+    const linkEmbedDetailsText = await linkEmbedLastMessage
+      .$(SELECTORS.CHAT_MESSAGE_LINK_EMBED_DETAILS)
+      .$(SELECTORS.CHAT_MESSAGE_LINK_EMBED_DETAILS_TEXT);
+    return linkEmbedDetailsText;
+  }
+
+  async getLastMessageReceivedLinkEmbedIcon() {
+    const linkEmbedLastMessage = await this.getLastMessageReceivedLinkEmbed();
+    const linkEmbedIcon = await linkEmbedLastMessage.$(
+      SELECTORS.CHAT_MESSAGE_LINK_EMBED_ICON
+    );
+    return linkEmbedIcon;
+  }
+
+  async getLastMessageReceivedLinkEmbedIconTitle() {
+    const linkEmbedIconLastMessage =
+      await this.getLastMessageReceivedLinkEmbedIcon();
+    const iconTitle = await linkEmbedIconLastMessage.$(
+      SELECTORS.CHAT_MESSAGE_LINK_EMBED_TITLE
+    );
+    return iconTitle;
+  }
+
+  async getLastMessageSentLinkEmbed() {
+    const lastMessage = await this.getLastMessageSentLocator();
+    const lastMessageLinkEmbed = await lastMessage.$(
+      SELECTORS.CHAT_MESSAGE_LINK_EMBED
+    );
+    return lastMessageLinkEmbed;
+  }
+
+  async getLastMessageSentLinkEmbedDetailsText() {
+    const linkEmbedLastMessage = await this.getLastMessageSentLinkEmbed();
+    const linkEmbedDetailsText = await linkEmbedLastMessage
+      .$(SELECTORS.CHAT_MESSAGE_LINK_EMBED_DETAILS)
+      .$(SELECTORS.CHAT_MESSAGE_LINK_EMBED_DETAILS_TEXT);
+    return linkEmbedDetailsText;
+  }
+
+  async getLastMessageSentLinkEmbedIcon() {
+    const linkEmbedLastMessage = await this.getLastMessageSentLinkEmbed();
+    const linkEmbedIcon = await linkEmbedLastMessage.$(
+      SELECTORS.CHAT_MESSAGE_LINK_EMBED_ICON
+    );
+    return linkEmbedIcon;
+  }
+
+  async getLastMessageSentLinkEmbedIconTitle() {
+    const linkEmbedIconLastMessage =
+      await this.getLastMessageSentLinkEmbedIcon();
+    const iconTitle = await linkEmbedIconLastMessage.$(
+      SELECTORS.CHAT_MESSAGE_LINK_EMBED_TITLE
+    );
+    return iconTitle;
   }
 
   // Context Menu Functions

--- a/tests/specs/reusable-accounts/04-message-input.spec.ts
+++ b/tests/specs/reusable-accounts/04-message-input.spec.ts
@@ -2,8 +2,10 @@ import { USER_A_INSTANCE, USER_B_INSTANCE } from "../../helpers/constants";
 import ChatsLayout from "../../screenobjects/chats/ChatsLayout";
 import InputBar from "../../screenobjects/chats/InputBar";
 import Messages from "../../screenobjects/chats/Messages";
+import chats from "../02-chats.spec";
 let chatsInputFirstUser = new InputBar(USER_A_INSTANCE);
 let chatsMessagesFirstUser = new Messages(USER_A_INSTANCE);
+let chatsMessagesSecondUser = new Messages(USER_B_INSTANCE);
 let chatsLayoutSecondUser = new ChatsLayout(USER_B_INSTANCE);
 
 export default async function messageInputTests() {
@@ -40,8 +42,117 @@ export default async function messageInputTests() {
     await chatsInputFirstUser.clearInputBar();
   });
 
-  it("Chat User B - Validate Typing Indicator is displayed if remote user is typing", async () => {
+  it("Chat Input Text - Validate texts with ** markdown are sent in bolds", async () => {
+    // With Chat User A
+    await chatsInputFirstUser.clearInputBar();
+    await chatsInputFirstUser.typeMessageOnInput("**Bolds1**");
+    await chatsInputFirstUser.clickOnSendMessage();
+    await chatsMessagesFirstUser.waitForMessageSentToExist("Bolds1");
+
+    // With Chat User B
+    await chatsLayoutSecondUser.switchToOtherUserWindow();
+    await chatsMessagesSecondUser.waitForReceivingMessage("Bolds1");
+  });
+
+  it("Chat Input Text - Validate texts with __ markdown are sent in bolds", async () => {
+    // With Chat User A
+    await chatsInputFirstUser.switchToOtherUserWindow();
+    await chatsInputFirstUser.typeMessageOnInput("__Bolds2__");
+    await chatsInputFirstUser.clickOnSendMessage();
+    await chatsMessagesFirstUser.waitForMessageSentToExist("Bolds2");
+
+    // With Chat User B
+    await chatsLayoutSecondUser.switchToOtherUserWindow();
+    await chatsMessagesSecondUser.waitForReceivingMessage("Bolds2");
+  });
+
+  it("Chat Input Text - Validate text starting with https:// is sent as link", async () => {
+    // With Chat User A
+    await chatsInputFirstUser.switchToOtherUserWindow();
+    await chatsInputFirstUser.typeMessageOnInput("https://www.google.com");
+    await chatsInputFirstUser.clickOnSendMessage();
+    await chatsMessagesFirstUser.waitForMessageSentToExist(
+      "https://www.google.com"
+    );
+
+    // With Chat User B
+    await chatsLayoutSecondUser.switchToOtherUserWindow();
+    await chatsMessagesSecondUser.waitForReceivingMessage(
+      "https://www.google.com"
+    );
+  });
+
+  it("Chat Input Text - Validate text starting with http:// is sent as link", async () => {
+    // With Chat User A
+    await chatsInputFirstUser.switchToOtherUserWindow();
+    await chatsInputFirstUser.typeMessageOnInput("http://www.satellite.im");
+    await chatsInputFirstUser.clickOnSendMessage();
+    await chatsMessagesFirstUser.waitForMessageSentToExist(
+      "http://www.satellite.im"
+    );
+
+    // With Chat User B
+    await chatsLayoutSecondUser.switchToOtherUserWindow();
+    await chatsMessagesSecondUser.waitForReceivingMessage(
+      "http://www.satellite.im"
+    );
+  });
+
+  it("Chat User - Chat Messages containing links contents on remote side", async () => {
+    // Validate link embed contents on chat message
+    const linkEmbedReceived =
+      await chatsMessagesSecondUser.getLastMessageReceivedLinkEmbed();
+    const linkEmbedReceivedDetailsText =
+      await chatsMessagesSecondUser.getLastMessageReceivedLinkEmbedDetailsText();
+    const linkEmbedReceivedIcon =
+      await chatsMessagesSecondUser.getLastMessageReceivedLinkEmbedIcon();
+    const linkEmbedReceivedIconTitle =
+      await chatsMessagesSecondUser.getLastMessageReceivedLinkEmbedIconTitle();
+
+    await expect(linkEmbedReceived).toBeDisplayed();
+    await expect(linkEmbedReceivedDetailsText).toHaveTextContaining(
+      "P2P Chat, Voice &#38; Video Open-source, stored on IPFS. End to end encryption... trackers not included."
+    );
+    await expect(linkEmbedReceivedIcon).toBeDisplayed();
+    await expect(linkEmbedReceivedIconTitle).toBeDisplayed();
+  });
+
+  it("Chat User - Chat Messages containing links contents on local side", async () => {
+    // Swith to Chat User A
+    await chatsMessagesFirstUser.switchToOtherUserWindow();
+
+    // Validate link embed contents on chat message
+    const linkEmbedSent =
+      await chatsMessagesFirstUser.getLastMessageSentLinkEmbed();
+    const linkEmbedSentDetailsText =
+      await chatsMessagesFirstUser.getLastMessageSentLinkEmbedDetailsText();
+    const linkEmbedSentIcon =
+      await chatsMessagesFirstUser.getLastMessageSentLinkEmbedIcon();
+    const linkEmbedSentIconTitle =
+      await chatsMessagesFirstUser.getLastMessageSentLinkEmbedIconTitle();
+
+    await expect(linkEmbedSent).toBeDisplayed();
+    await expect(linkEmbedSentDetailsText).toHaveTextContaining(
+      "P2P Chat, Voice &#38; Video Open-source, stored on IPFS. End to end encryption... trackers not included."
+    );
+    await expect(linkEmbedSentIcon).toBeDisplayed();
+    await expect(linkEmbedSentIconTitle).toBeDisplayed();
+  });
+
+  it("Chat Input Text - Validate text starting with www. is not sent as link", async () => {
+    // With Chat User A
+    await chatsInputFirstUser.typeMessageOnInput("www.apple.com");
+    await chatsInputFirstUser.clickOnSendMessage();
+    await chatsMessagesFirstUser.waitForMessageSentToExist("www.apple.com");
+
+    // With Chat User B
+    await chatsLayoutSecondUser.switchToOtherUserWindow();
+    await chatsMessagesSecondUser.waitForReceivingMessage("www.apple.com");
+  });
+
+  it("Validate Typing Indicator is displayed if remote user is typing", async () => {
     // With User A
+    await chatsInputFirstUser.switchToOtherUserWindow();
     // Generate a random text with 100 chars
     const shortText = await chatsInputFirstUser.generateShortRandomText();
     // Type the text with 90 chars on input bar


### PR DESCRIPTION
### What this PR does 📖

- Add tests to validate chat input markdowns for bolds ** and __
- Add tests to validate sending texts starting with https:// and http:// as links
- Add tests to validate text starting with www. is not sent as link
- Add tests on remote side to validate user can receive messages with links and bold markdowns
- Updated screenobject file of Messages to add required methods for these validations

### Which issue(s) this PR fixes 🔨

- Resolve #275 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
