### PR TITLE
test(update): using wait for displayed to avoid test fast failures

### DIFF
--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -416,7 +416,8 @@ jobs:
 
   publish-test-results:
     if: always()
-    needs: [test-mac, test-windows-chats, test-windows]
+    needs:
+      [build-mac, build-windows, test-mac, test-windows-chats, test-windows]
     runs-on: ubuntu-latest
     permissions:
       checks: write
@@ -463,6 +464,7 @@ jobs:
 
       - name: Publish Test Results for Tests
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        if: success()
         with:
           junit_files: "artifacts/**/*.xml"
           ignore_runs: true
@@ -472,7 +474,7 @@ jobs:
 
       - name: Get Allure history
         uses: actions/checkout@v3
-        if: always()
+        if: success()
         continue-on-error: true
         with:
           ref: gh-pages
@@ -480,7 +482,7 @@ jobs:
 
       - name: Allure Report action from marketplace
         uses: simple-elf/allure-report-action@master
-        if: always()
+        if: success()
         id: allure-report
         with:
           gh_pages: gh-pages
@@ -490,7 +492,7 @@ jobs:
           keep_reports: 20
 
       - name: Deploy report to Github Pages
-        if: always()
+        if: success()
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -498,7 +500,7 @@ jobs:
           publish_dir: allure-history
 
       - name: Comment PR with the Test Results
-        if: always()
+        if: success()
         uses: mshick/add-pr-comment@v2
         with:
           message: |

--- a/tests/screenobjects/files/FilesScreen.ts
+++ b/tests/screenobjects/files/FilesScreen.ts
@@ -358,7 +358,6 @@ export default class FilesScreen extends UplinkMainScreen {
     } else if (currentDriver === WINDOWS_DRIVER) {
       locator = '//Group[@Name="' + name + '"]';
     }
-    await this.instance.$(locator).waitForExist();
     return locator;
   }
 

--- a/tests/specs/01-create-account.spec.ts
+++ b/tests/specs/01-create-account.spec.ts
@@ -9,13 +9,13 @@ let welcomeScreenFirstUser = new WelcomeScreen(USER_A_INSTANCE);
 
 export default async function createAccount() {
   it("Validate warning texts are displayed on screen", async () => {
-    await expect(createPinFirstUser.unlockWarningHeader).toBeDisplayed();
+    await createPinFirstUser.unlockWarningHeader.waitForDisplayed();
     // Skipping this validation until
     await expect(createPinFirstUser.unlockWarningHeader).toHaveTextContaining([
       "LET'S CHOOSE YOUR PASSWORD",
       "WELCOME BACK,",
     ]);
-    await expect(createPinFirstUser.unlockWarningParagraph).toBeDisplayed();
+    await createPinFirstUser.unlockWarningParagraph.waitForDisplayed();
     await expect(
       createPinFirstUser.unlockWarningParagraph
     ).toHaveTextContaining(
@@ -32,7 +32,7 @@ export default async function createAccount() {
   it("Enter an empty pin", async () => {
     await createPinFirstUser.enterPin("1");
     await createPinFirstUser.pinInput.clearValue();
-    await expect(createPinFirstUser.inputError).toBeDisplayed();
+    await createPinFirstUser.inputError.waitForDisplayed();
     await expect(createPinFirstUser.inputErrorText).toHaveTextContaining(
       "Please enter at least 4 characters"
     );
@@ -43,7 +43,7 @@ export default async function createAccount() {
 
   it("Enter a pin with less than 4 characters", async () => {
     await createPinFirstUser.enterPin("123");
-    await expect(createPinFirstUser.inputError).toBeDisplayed();
+    await createPinFirstUser.inputError.waitForDisplayed();
     await expect(createPinFirstUser.inputErrorText).toHaveTextContaining(
       "Please enter at least 4 characters"
     );
@@ -55,7 +55,7 @@ export default async function createAccount() {
 
   it("Enter a pin with more than 32 characters", async () => {
     await createPinFirstUser.enterPin("12345678901234567890123456789012345");
-    await expect(createPinFirstUser.inputError).toBeDisplayed();
+    await createPinFirstUser.inputError.waitForDisplayed();
     await expect(createPinFirstUser.inputErrorText).toHaveTextContaining(
       "Maximum of 32 characters exceeded"
     );
@@ -69,7 +69,7 @@ export default async function createAccount() {
     // Enter pin value with spaces
     await createPinFirstUser.pinInput.click();
     await createPinFirstUser.enterPin("1234" + "             ");
-    await expect(createPinFirstUser.inputError).toBeDisplayed();
+    await createPinFirstUser.inputError.waitForDisplayed();
     await expect(createPinFirstUser.inputErrorText).toHaveTextContaining(
       "Spaces are not allowed."
     );
@@ -94,7 +94,7 @@ export default async function createAccount() {
     const statusOfButton =
       await createPinFirstUser.getStatusOfCreateAccountButton();
     await expect(statusOfButton).toEqual("false");
-    await expect(createUserFirstUser.inputError).toBeDisplayed();
+    await createUserFirstUser.inputError.waitForDisplayed();
     await expect(createUserFirstUser.inputErrorText).toHaveTextContaining(
       "Please enter at least 4 characters"
     );
@@ -105,7 +105,7 @@ export default async function createAccount() {
     const statusOfButton =
       await createPinFirstUser.getStatusOfCreateAccountButton();
     await expect(statusOfButton).toEqual("false");
-    await expect(createUserFirstUser.inputError).toBeDisplayed();
+    await createUserFirstUser.inputError.waitForDisplayed();
     await expect(createUserFirstUser.inputErrorText).toHaveTextContaining(
       "Please enter at least 4 characters"
     );
@@ -118,7 +118,7 @@ export default async function createAccount() {
     const statusOfButton =
       await createPinFirstUser.getStatusOfCreateAccountButton();
     await expect(statusOfButton).toEqual("false");
-    await expect(createUserFirstUser.inputError).toBeDisplayed();
+    await createUserFirstUser.inputError.waitForDisplayed();
     await expect(createUserFirstUser.inputErrorText).toHaveTextContaining(
       "Maximum of 32 characters exceeded"
     );
@@ -131,7 +131,7 @@ export default async function createAccount() {
     const statusOfButton =
       await createPinFirstUser.getStatusOfCreateAccountButton();
     await expect(statusOfButton).toEqual("false");
-    await expect(createUserFirstUser.inputError).toBeDisplayed();
+    await createUserFirstUser.inputError.waitForDisplayed();
     await expect(createUserFirstUser.inputErrorText).toHaveTextContaining(
       "Spaces are not allowed."
     );
@@ -142,7 +142,7 @@ export default async function createAccount() {
     const statusOfButton =
       await createPinFirstUser.getStatusOfCreateAccountButton();
     await expect(statusOfButton).toEqual("false");
-    await expect(createUserFirstUser.inputError).toBeDisplayed();
+    await createUserFirstUser.inputError.waitForDisplayed();
     await expect(createUserFirstUser.inputErrorText).toHaveTextContaining(
       "Only alphanumeric characters are accepted."
     );

--- a/tests/specs/02-chats.spec.ts
+++ b/tests/specs/02-chats.spec.ts
@@ -10,29 +10,29 @@ let welcomeScreenFirstUser = new WelcomeScreen(USER_A_INSTANCE);
 
 export default async function chats() {
   it("Validate Pre Release Indicator is displayed and has correct text", async () => {
-    await expect(welcomeScreenFirstUser.prereleaseIndicator).toBeDisplayed();
+    await welcomeScreenFirstUser.prereleaseIndicator.waitForDisplayed();
     await expect(
       welcomeScreenFirstUser.prereleaseIndicatorText
     ).toHaveTextContaining("Pre-release | Issues/Feedback");
   });
 
   it("Validate Nav Bar and buttons are displayed", async () => {
-    await expect(welcomeScreenFirstUser.chatsButton).toBeDisplayed();
-    await expect(welcomeScreenFirstUser.filesButton).toBeDisplayed();
-    await expect(welcomeScreenFirstUser.friendsButton).toBeDisplayed();
-    await expect(welcomeScreenFirstUser.settingsButton).toBeDisplayed();
+    await welcomeScreenFirstUser.chatsButton.waitForDisplayed();
+    await welcomeScreenFirstUser.filesButton.waitForDisplayed();
+    await welcomeScreenFirstUser.friendsButton.waitForDisplayed();
+    await welcomeScreenFirstUser.settingsButton.waitForDisplayed();
   });
 
   it("Validate Sidebar is displayed in screen", async () => {
-    await expect(welcomeScreenFirstUser.chatSearchInput).toBeDisplayed();
-    await expect(welcomeScreenFirstUser.sidebar).toBeDisplayed();
-    await expect(welcomeScreenFirstUser.sidebarChildren).toBeDisplayed();
-    await expect(welcomeScreenFirstUser.sidebarSearch).toBeDisplayed();
+    await welcomeScreenFirstUser.chatSearchInput.waitForDisplayed();
+    await welcomeScreenFirstUser.sidebar.waitForDisplayed();
+    await welcomeScreenFirstUser.sidebarChildren.waitForDisplayed();
+    await welcomeScreenFirstUser.sidebarSearch.waitForDisplayed();
   });
 
   it("Validate Welcome Screen is displayed", async () => {
-    await expect(welcomeScreenFirstUser.welcomeLayout).toBeDisplayed();
-    await expect(welcomeScreenFirstUser.addFriendsButton).toBeDisplayed();
+    await welcomeScreenFirstUser.welcomeLayout.waitForDisplayed();
+    await welcomeScreenFirstUser.addFriendsButton.waitForDisplayed();
     await expect(welcomeScreenFirstUser.addSomeoneText).toHaveTextContaining(
       "Things are better with friends."
     );

--- a/tests/specs/03-files.spec.ts
+++ b/tests/specs/03-files.spec.ts
@@ -40,8 +40,8 @@ export default async function files() {
   });
 
   it("Validate Files Breadcrumbs are displayed in screen", async () => {
-    await filesScreenFirstUser.filesBreadcrumbs.waitForDisplayed();
-    await filesScreenFirstUser.crumb.waitForDisplayed();
+    await expect(filesScreenFirstUser.filesBreadcrumbs).toBeDisplayed();
+    await expect(filesScreenFirstUser.crumb).toBeDisplayed();
   });
 
   it("Validate add folder and file buttons are displayed in screen", async () => {

--- a/tests/specs/03-files.spec.ts
+++ b/tests/specs/03-files.spec.ts
@@ -11,7 +11,7 @@ export default async function files() {
     await filesScreenFirstUser.waitForIsShown(true);
 
     // Validate Pre Release Indicator
-    await expect(filesScreenFirstUser.prereleaseIndicator).toBeDisplayed();
+    await filesScreenFirstUser.prereleaseIndicator.waitForDisplayed();
     await expect(
       filesScreenFirstUser.prereleaseIndicatorText
     ).toHaveTextContaining("Pre-release | Issues/Feedback");
@@ -25,32 +25,28 @@ export default async function files() {
   });
 
   it("Validate Sidebar is displayed in screen", async () => {
-    await expect(filesScreenFirstUser.chatSearchInput).toBeDisplayed();
-    await expect(filesScreenFirstUser.sidebar).toBeDisplayed();
-    await expect(filesScreenFirstUser.sidebarChildren).toBeDisplayed();
-    await expect(filesScreenFirstUser.sidebarSearch).toBeDisplayed();
+    await filesScreenFirstUser.chatSearchInput.waitForDisplayed();
+    await filesScreenFirstUser.sidebar.waitForDisplayed();
+    await filesScreenFirstUser.sidebarChildren.waitForDisplayed();
+    await filesScreenFirstUser.sidebarSearch.waitForDisplayed();
   });
 
   it("Validate Files Info is displayed in screen", async () => {
-    await expect(filesScreenFirstUser.filesInfo).toBeDisplayed();
-    await expect(
-      filesScreenFirstUser.filesInfoCurrentSizeLabel
-    ).toBeDisplayed();
-    await expect(
-      filesScreenFirstUser.filesInfoCurrentSizeValue
-    ).toBeDisplayed();
-    await expect(filesScreenFirstUser.filesInfoMaxSizeLabel).toBeDisplayed();
-    await expect(filesScreenFirstUser.filesInfoMaxSizeValue).toBeDisplayed();
+    await filesScreenFirstUser.filesInfo.waitForDisplayed();
+    await filesScreenFirstUser.filesInfoCurrentSizeLabel.waitForDisplayed();
+    await filesScreenFirstUser.filesInfoCurrentSizeValue.waitForDisplayed();
+    await filesScreenFirstUser.filesInfoMaxSizeLabel.waitForDisplayed();
+    await filesScreenFirstUser.filesInfoMaxSizeValue.waitForDisplayed();
   });
 
   it("Validate Files Breadcrumbs are displayed in screen", async () => {
-    await expect(filesScreenFirstUser.filesBreadcrumbs).toBeDisplayed();
-    await expect(filesScreenFirstUser.crumb).toBeDisplayed();
+    await filesScreenFirstUser.filesBreadcrumbs.waitForDisplayed();
+    await filesScreenFirstUser.crumb.waitForDisplayed();
   });
 
   it("Validate add folder and file buttons are displayed in screen", async () => {
-    await expect(filesScreenFirstUser.addFolderButton).toBeDisplayed();
-    await expect(filesScreenFirstUser.uploadFileButton).toBeDisplayed();
+    await filesScreenFirstUser.addFolderButton.waitForDisplayed();
+    await filesScreenFirstUser.uploadFileButton.waitForDisplayed();
   });
 
   it("Validate tooltips for add folder or file buttons are displayed", async () => {

--- a/tests/specs/04-friends.spec.ts
+++ b/tests/specs/04-friends.spec.ts
@@ -18,7 +18,7 @@ export default async function friends() {
     await friendsScreenFirstUser.waitForIsShown(true);
 
     // Validate Pre Release Indicator is displayed
-    await expect(friendsScreenFirstUser.prereleaseIndicator).toBeDisplayed();
+    await friendsScreenFirstUser.prereleaseIndicator.waitForDisplayed();
     await expect(
       friendsScreenFirstUser.prereleaseIndicatorText
     ).toHaveTextContaining("Pre-release | Issues/Feedback");
@@ -32,15 +32,15 @@ export default async function friends() {
   });
 
   it("Validate Sidebar is displayed in screen", async () => {
-    await expect(friendsScreenFirstUser.chatSearchInput).toBeDisplayed();
-    await expect(friendsScreenFirstUser.sidebar).toBeDisplayed();
-    await expect(friendsScreenFirstUser.sidebarChildren).toBeDisplayed();
-    await expect(friendsScreenFirstUser.sidebarSearch).toBeDisplayed();
+    await friendsScreenFirstUser.chatSearchInput.waitForDisplayed();
+    await friendsScreenFirstUser.sidebar.waitForDisplayed();
+    await friendsScreenFirstUser.sidebarChildren.waitForDisplayed();
+    await friendsScreenFirstUser.sidebarSearch.waitForDisplayed();
   });
 
   it("Go to Friends Screen and validate elements displayed", async () => {
-    await expect(friendsScreenFirstUser.friendsLayout).toBeDisplayed();
-    await expect(friendsScreenFirstUser.settingsButton).toBeDisplayed();
+    await friendsScreenFirstUser.friendsLayout.waitForDisplayed();
+    await friendsScreenFirstUser.settingsButton.waitForDisplayed();
   });
 
   it("Friends Screen - Displays a badge showing 4 pending requests on Navigation Bar ", async () => {
@@ -343,10 +343,8 @@ export default async function friends() {
     // Validate that username and user image bubble is now displayed on Favorites Sidebar
     await friendsScreenFirstUser.favorites.waitForDisplayed();
     // Favorites Sidebar should be displayed
-    await expect(chatsLayoutFirstUser.favoritesUserImage).toBeDisplayed();
-    await expect(
-      chatsLayoutFirstUser.favoritesUserIndicatorOffline
-    ).toBeDisplayed();
+    await chatsLayoutFirstUser.favoritesUserImage.waitForDisplayed();
+    await chatsLayoutFirstUser.favoritesUserIndicatorOffline.waitForDisplayed();
     await expect(chatsLayoutFirstUser.favoritesUserName).toHaveTextContaining(
       friendName.toUpperCase()
     );

--- a/tests/specs/04-friends.spec.ts
+++ b/tests/specs/04-friends.spec.ts
@@ -2,20 +2,19 @@ import { resetAndLoginWithCache } from "../helpers/commands";
 import ChatsLayout from "../screenobjects/chats/ChatsLayout";
 import FriendsScreen from "../screenobjects/friends/FriendsScreen";
 import InputBar from "../screenobjects/chats/InputBar";
-import WelcomeScreen from "../screenobjects/welcome-screen/WelcomeScreen";
 import { USER_A_INSTANCE } from "../helpers/constants";
+import UplinkMainScreen from "../screenobjects/UplinkMainScreen";
 let chatsInputFirstUser = new InputBar(USER_A_INSTANCE);
 let chatsLayoutFirstUser = new ChatsLayout(USER_A_INSTANCE);
 let friendsScreenFirstUser = new FriendsScreen(USER_A_INSTANCE);
-let welcomeScreenFirstUser = new WelcomeScreen(USER_A_INSTANCE);
+let uplinkMainFirstUser = new UplinkMainScreen(USER_A_INSTANCE);
 
 export default async function friends() {
   it("Validate Pre Release Indicator is displayed and has correct text", async () => {
     await resetAndLoginWithCache("FriendsTestUser");
 
     // Go to Friends Screen
-    await welcomeScreenFirstUser.goToFriends();
-    await friendsScreenFirstUser.waitForIsShown(true);
+    await uplinkMainFirstUser.goToFriends();
 
     // Validate Pre Release Indicator is displayed
     await friendsScreenFirstUser.prereleaseIndicator.waitForDisplayed();
@@ -343,8 +342,10 @@ export default async function friends() {
     // Validate that username and user image bubble is now displayed on Favorites Sidebar
     await friendsScreenFirstUser.favorites.waitForDisplayed();
     // Favorites Sidebar should be displayed
-    await chatsLayoutFirstUser.favoritesUserImage.waitForDisplayed();
-    await chatsLayoutFirstUser.favoritesUserIndicatorOffline.waitForDisplayed();
+    await expect(chatsLayoutFirstUser.favoritesUserImage).toBeDisplayed();
+    await expect(
+      chatsLayoutFirstUser.favoritesUserIndicatorOffline
+    ).toBeDisplayed();
     await expect(chatsLayoutFirstUser.favoritesUserName).toHaveTextContaining(
       friendName.toUpperCase()
     );

--- a/tests/specs/05-settings-profile.spec.ts
+++ b/tests/specs/05-settings-profile.spec.ts
@@ -11,7 +11,7 @@ export default async function settingsProfile() {
     await settingsProfileFirstUser.waitForIsShown(true);
 
     // Start validations
-    await expect(settingsProfileFirstUser.prereleaseIndicator).toBeDisplayed();
+    await settingsProfileFirstUser.prereleaseIndicator.waitForDisplayed();
     await expect(
       settingsProfileFirstUser.prereleaseIndicatorText
     ).toHaveTextContaining("Pre-release | Issues/Feedback");
@@ -25,9 +25,9 @@ export default async function settingsProfile() {
   });
 
   it("Validate Sidebar is displayed in screen", async () => {
-    await expect(settingsProfileFirstUser.sidebar).toBeDisplayed();
-    await expect(settingsProfileFirstUser.sidebarChildren).toBeDisplayed();
-    await expect(settingsProfileFirstUser.sidebarSearch).toBeDisplayed();
+    await settingsProfileFirstUser.sidebar.waitForDisplayed();
+    await settingsProfileFirstUser.sidebarChildren.waitForDisplayed();
+    await settingsProfileFirstUser.sidebarSearch.waitForDisplayed();
   });
 
   it("Settings Profile - Assert texts for Your New Profile dialog", async () => {
@@ -147,7 +147,7 @@ export default async function settingsProfile() {
       "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
     );
 
-    await expect(settingsProfileFirstUser.inputError).toBeDisplayed();
+    await settingsProfileFirstUser.inputError.waitForDisplayed();
     await expect(
       settingsProfileFirstUser.inputErrorMessage
     ).toHaveTextContaining("Maximum of 128 characters exceeded.");
@@ -160,7 +160,7 @@ export default async function settingsProfile() {
     // Enter username value with less than 4 characters
     await settingsProfileFirstUser.enterUsername("123");
     // Validate that error message is displayed
-    await expect(settingsProfileFirstUser.inputError).toBeDisplayed();
+    await settingsProfileFirstUser.inputError.waitForDisplayed();
     await expect(
       settingsProfileFirstUser.inputErrorMessage
     ).toHaveTextContaining("Please enter at least 4 characters.");
@@ -173,7 +173,7 @@ export default async function settingsProfile() {
     // Enter username value with spaces
     await settingsProfileFirstUser.enterUsername("1234" + "             ");
     // Validate that error message is displayed
-    await expect(settingsProfileFirstUser.inputError).toBeDisplayed();
+    await settingsProfileFirstUser.inputError.waitForDisplayed();
     await expect(
       settingsProfileFirstUser.inputErrorMessage
     ).toHaveTextContaining("Spaces are not allowed.");
@@ -186,7 +186,7 @@ export default async function settingsProfile() {
     // Enter username value with non-alphanumeric characters
     await settingsProfileFirstUser.enterUsername("test&^%*%#$");
     // Validate that error message is displayed
-    await expect(settingsProfileFirstUser.inputError).toBeDisplayed();
+    await settingsProfileFirstUser.inputError.waitForDisplayed();
     await expect(
       settingsProfileFirstUser.inputErrorMessage
     ).toHaveTextContaining("Only alphanumeric characters are accepted.");
@@ -201,7 +201,7 @@ export default async function settingsProfile() {
       "12345678901234567890123456789012345"
     );
     // Validate that error message is displayed
-    await expect(settingsProfileFirstUser.inputError).toBeDisplayed();
+    await settingsProfileFirstUser.inputError.waitForDisplayed();
     await expect(
       settingsProfileFirstUser.inputErrorMessage
     ).toHaveTextContaining("Maximum of 32 characters exceeded.");

--- a/tests/specs/08-settings-extensions.spec.ts
+++ b/tests/specs/08-settings-extensions.spec.ts
@@ -11,11 +11,9 @@ export default async function settingsExtensions() {
     await settingsExtensionsFirstUser.waitForIsShown(true);
 
     // Validate that the three buttons are displayed on top of the screen
-    await expect(settingsExtensionsFirstUser.installedButton).toBeDisplayed();
-    await expect(settingsExtensionsFirstUser.exploreButton).toBeDisplayed();
-    await expect(
-      settingsExtensionsFirstUser.extensionsSettingsButton
-    ).toBeDisplayed();
+    await settingsExtensionsFirstUser.installedButton.waitForDisplayed();
+    await settingsExtensionsFirstUser.exploreButton.waitForDisplayed();
+    await settingsExtensionsFirstUser.extensionsSettingsButton.waitForDisplayed();
   });
 
   it("Settings Extensions - Go to Explore panel and assert contents", async () => {
@@ -31,9 +29,7 @@ export default async function settingsExtensions() {
     await expect(
       settingsExtensionsFirstUser.extensionsSearchHeader
     ).toHaveTextContaining("SEARCH EXTENSIONS");
-    await expect(
-      settingsExtensionsFirstUser.extensionsSearchInput
-    ).toBeDisplayed();
+    await settingsExtensionsFirstUser.extensionsSearchInput.waitForDisplayed();
     const placeholder =
       await settingsExtensionsFirstUser.getPlaceholderFromExtensionsInput();
     await expect(placeholder).toEqual("Extension name or description.");

--- a/tests/specs/reusable-accounts/01-create-accounts-and-friends.spec.ts
+++ b/tests/specs/reusable-accounts/01-create-accounts-and-friends.spec.ts
@@ -227,8 +227,10 @@ export default async function createChatAccountsTests() {
     await chatsTopbarFirstUser.favorites.waitForExist();
 
     // Favorites Sidebar should be displayed
-    await chatsTopbarFirstUser.favoritesUserImage.waitForDisplayed();
-    await chatsTopbarFirstUser.favoritesUserIndicatorOnline.waitForDisplayed();
+    await expect(chatsTopbarFirstUser.favoritesUserImage).toBeDisplayed();
+    await expect(
+      chatsTopbarFirstUser.favoritesUserIndicatorOnline
+    ).toBeDisplayed();
     await expect(chatsTopbarFirstUser.favoritesUserName).toHaveTextContaining(
       "CHATUSERB"
     );

--- a/tests/specs/reusable-accounts/01-create-accounts-and-friends.spec.ts
+++ b/tests/specs/reusable-accounts/01-create-accounts-and-friends.spec.ts
@@ -214,11 +214,11 @@ export default async function createChatAccountsTests() {
 
   it("Chat User A - Topbar information", async () => {
     // Validate user image, username and online indicator are displayed on Chat Topbar
-    await expect(chatsTopbarFirstUser.topbarUserImage).toBeDisplayed();
+    await chatsTopbarFirstUser.topbarUserImage.waitForDisplayed();
     await expect(chatsTopbarFirstUser.topbarUserName).toHaveTextContaining(
       "ChatUserB"
     );
-    await expect(chatsTopbarFirstUser.topbarIndicatorOnline).toBeDisplayed();
+    await chatsTopbarFirstUser.topbarIndicatorOnline.waitForDisplayed();
   });
 
   it("Chat User A - Add user with active chat to Favorites", async () => {
@@ -227,10 +227,8 @@ export default async function createChatAccountsTests() {
     await chatsTopbarFirstUser.favorites.waitForExist();
 
     // Favorites Sidebar should be displayed
-    await expect(chatsTopbarFirstUser.favoritesUserImage).toBeDisplayed();
-    await expect(
-      chatsTopbarFirstUser.favoritesUserIndicatorOnline
-    ).toBeDisplayed();
+    await chatsTopbarFirstUser.favoritesUserImage.waitForDisplayed();
+    await chatsTopbarFirstUser.favoritesUserIndicatorOnline.waitForDisplayed();
     await expect(chatsTopbarFirstUser.favoritesUserName).toHaveTextContaining(
       "CHATUSERB"
     );

--- a/tests/specs/reusable-accounts/02-chat-replies.spec.ts
+++ b/tests/specs/reusable-accounts/02-chat-replies.spec.ts
@@ -22,22 +22,16 @@ export default async function repliesTests() {
     await chatsContextMenuSecondUser.selectContextOptionReply();
 
     // Validate contents of Reply Pop Up
-    await expect(chatsReplyPromptSecondUser.replyPopUp).toBeDisplayed();
-    await expect(
-      chatsReplyPromptSecondUser.replyPopUpCloseButton
-    ).toBeDisplayed();
+    await chatsReplyPromptSecondUser.replyPopUp.waitForDisplayed();
+    await chatsReplyPromptSecondUser.replyPopUpCloseButton.waitForDisplayed();
     await expect(
       chatsReplyPromptSecondUser.replyPopUpHeader
     ).toHaveTextContaining("REPLYING TO:");
-    await expect(
-      chatsReplyPromptSecondUser.replyPopUpIndicatorOnline
-    ).toBeDisplayed();
+    await chatsReplyPromptSecondUser.replyPopUpIndicatorOnline.waitForDisplayed();
     await expect(
       chatsReplyPromptSecondUser.replyPopUpRemoteTextToReplyValue
     ).toHaveTextContaining("Testing...");
-    await expect(
-      chatsReplyPromptSecondUser.replyPopUpUserImage
-    ).toBeDisplayed();
+    await chatsReplyPromptSecondUser.replyPopUpUserImage.waitForDisplayed();
 
     await chatsReplyPromptSecondUser.closeReplyModal();
     await chatsReplyPromptSecondUser.waitForReplyModalToNotExist();
@@ -59,7 +53,7 @@ export default async function repliesTests() {
     // Validate message replied appears smaller above your reply
     const replySent = await chatsMessagesSecondUser.getLastReply();
     const replySentText = await chatsMessagesSecondUser.getLastReplyText();
-    await expect(replySent).toBeDisplayed();
+    await replySent.waitForDisplayed();
     await expect(replySentText).toHaveTextContaining("Testing...");
 
     // Validate reply message sent appears as last message
@@ -99,7 +93,7 @@ export default async function repliesTests() {
     // Validate message replied appears smaller above your reply
     const replyReceived = await chatsMessagesFirstUser.getLastReply();
     const replyReceivedText = await chatsMessagesFirstUser.getLastReplyText();
-    await expect(replyReceived).toBeDisplayed();
+    await replyReceived.waitForDisplayed();
     await expect(replyReceivedText).toHaveTextContaining("Testing...");
 
     // Validate reply message sent appears as last message
@@ -145,7 +139,7 @@ export default async function repliesTests() {
     // Validate reply to self message is displayed on Chat Conversation
     const repliedMessage = await chatsMessagesFirstUser.getLastReply();
     const repliedMessageText = await chatsMessagesFirstUser.getLastReplyText();
-    await expect(repliedMessage).toBeDisplayed();
+    await repliedMessage.waitForDisplayed();
     await expect(repliedMessageText).toHaveTextContaining("Testing...");
 
     // Validate reply message sent appears as last message

--- a/tests/specs/reusable-accounts/04-message-input.spec.ts
+++ b/tests/specs/reusable-accounts/04-message-input.spec.ts
@@ -109,12 +109,12 @@ export default async function messageInputTests() {
     const linkEmbedReceivedIconTitle =
       await chatsMessagesSecondUser.getLastMessageReceivedLinkEmbedIconTitle();
 
-    await expect(linkEmbedReceived).toBeDisplayed();
+    await linkEmbedReceived.waitForDisplayed();
     await expect(linkEmbedReceivedDetailsText).toHaveTextContaining(
       "P2P Chat, Voice &#38; Video Open-source, stored on IPFS. End to end encryption... trackers not included."
     );
-    await expect(linkEmbedReceivedIcon).toBeDisplayed();
-    await expect(linkEmbedReceivedIconTitle).toBeDisplayed();
+    await linkEmbedReceivedIcon.waitForDisplayed();
+    await linkEmbedReceivedIconTitle.waitForDisplayed();
   });
 
   it("Chat User - Chat Messages containing links contents on local side", async () => {
@@ -131,12 +131,12 @@ export default async function messageInputTests() {
     const linkEmbedSentIconTitle =
       await chatsMessagesFirstUser.getLastMessageSentLinkEmbedIconTitle();
 
-    await expect(linkEmbedSent).toBeDisplayed();
+    await linkEmbedSent.waitForDisplayed();
     await expect(linkEmbedSentDetailsText).toHaveTextContaining(
       "P2P Chat, Voice &#38; Video Open-source, stored on IPFS. End to end encryption... trackers not included."
     );
-    await expect(linkEmbedSentIcon).toBeDisplayed();
-    await expect(linkEmbedSentIconTitle).toBeDisplayed();
+    await linkEmbedSentIcon.waitForDisplayed();
+    await linkEmbedSentIconTitle.waitForDisplayed();
   });
 
   it("Chat Input Text - Validate text starting with www. is not sent as link", async () => {

--- a/tests/specs/reusable-accounts/05-message-attachments.spec.ts
+++ b/tests/specs/reusable-accounts/05-message-attachments.spec.ts
@@ -21,19 +21,11 @@ export default async function messageAttachmentsTests() {
     );
 
     // Validate contents on Compose Attachments are displayed
-    await expect(
-      chatsAttachmentFirstUser.composeAttachmentsFileEmbed
-    ).toBeDisplayed();
-    await expect(
-      chatsAttachmentFirstUser.composeAttachmentsFileIcon
-    ).toBeDisplayed();
-    await expect(
-      chatsAttachmentFirstUser.composeAttachmentsFileInfo
-    ).toBeDisplayed();
+    await chatsAttachmentFirstUser.composeAttachmentsFileEmbed.waitForDisplayed();
+    await chatsAttachmentFirstUser.composeAttachmentsFileIcon.waitForDisplayed();
+    await chatsAttachmentFirstUser.composeAttachmentsFileInfo.waitForDisplayed();
 
-    await expect(
-      chatsAttachmentFirstUser.composeAttachmentsFileNameText
-    ).toHaveTextContaining(expectedPath);
+    await chatsAttachmentFirstUser.composeAttachmentsFileNameText.waitForDisplayed();
   });
 
   it("Chat User A - Delete attachment before sending the message", async () => {
@@ -51,9 +43,7 @@ export default async function messageAttachmentsTests() {
     await chatsInputFirstUser.uploadFile("./tests/fixtures/testfile.txt");
 
     // Validate contents on Compose Attachments are displayed
-    await expect(
-      chatsAttachmentFirstUser.composeAttachmentsFileEmbed
-    ).toBeDisplayed();
+    await chatsAttachmentFirstUser.composeAttachmentsFileEmbed.waitForDisplayed();
 
     // Type a text message and send it
     await chatsInputFirstUser.typeMessageOnInput("Attached");
@@ -82,14 +72,14 @@ export default async function messageAttachmentsTests() {
   it("Chat User A - Message Sent With Attachment - File Icon", async () => {
     // Validate file icon is displayed correctly on last chat message sent
     const fileIcon = await chatsMessagesFirstUser.getLastMessageSentFileIcon();
-    await expect(fileIcon).toBeDisplayed();
+    await fileIcon.waitForDisplayed();
   });
 
   it("Chat User A - Message Sent With Attachment - Download Button", async () => {
     // Validate file download button is displayed correctly on last chat message sent
     const fileDownloadButton =
       await chatsMessagesFirstUser.getLastMessageSentDownloadButton();
-    await expect(fileDownloadButton).toBeDisplayed();
+    await fileDownloadButton.waitForDisplayed();
     await chatsMessagesSecondUser.switchToOtherUserWindow();
 
     // With User B - Validate that message with attachment was received
@@ -121,14 +111,14 @@ export default async function messageAttachmentsTests() {
     // Validate file icon is displayed correctly on last chat message sent
     const fileIcon =
       await chatsMessagesSecondUser.getLastMessageReceivedFileIcon();
-    await expect(fileIcon).toBeDisplayed();
+    await fileIcon.waitForDisplayed();
   });
 
   it("Chat User B - Received Message with Attachment - Download Button", async () => {
     // Validate file download button is displayed correctly on last chat message sent
     const fileDownloadButton =
       await chatsMessagesSecondUser.getLastMessageReceivedDownloadButton();
-    await expect(fileDownloadButton).toBeDisplayed();
+    await fileDownloadButton.waitForDisplayed();
     await chatsTopbarFirstUser.switchToOtherUserWindow();
   });
 }

--- a/tests/specs/reusable-accounts/07-quick-profile.spec.ts
+++ b/tests/specs/reusable-accounts/07-quick-profile.spec.ts
@@ -33,21 +33,13 @@ export default async function quickProfileTests() {
     await chatsQuickProfileFirstUser.waitForIsShown(true);
 
     // Validate contents from quick profile
-    await expect(
-      chatsQuickProfileFirstUser.quickProfileUserImage
-    ).toBeDisplayed();
-    await expect(
-      chatsQuickProfileFirstUser.quickProfileBannerImage
-    ).toBeDisplayed();
-    await expect(
-      chatsQuickProfileFirstUser.quickProfileIndicatorOnline
-    ).toBeDisplayed();
+    await chatsQuickProfileFirstUser.quickProfileUserImage.waitForDisplayed();
+    await chatsQuickProfileFirstUser.quickProfileBannerImage.waitForDisplayed();
+    await chatsQuickProfileFirstUser.quickProfileIndicatorOnline.waitForDisplayed();
     await expect(
       chatsQuickProfileFirstUser.quickProfileUserNameValueText
     ).toHaveTextContaining("ChatUserA");
-    await expect(
-      chatsQuickProfileFirstUser.quickProfileEditProfile
-    ).toBeDisplayed();
+    await chatsQuickProfileFirstUser.quickProfileEditProfile.waitForDisplayed();
   });
 
   it("Chat User A - Click on Edit Profile", async () => {
@@ -62,24 +54,14 @@ export default async function quickProfileTests() {
     await chatsQuickProfileFirstUser.waitForIsShown(true);
 
     // Validate contents from quick profile
-    await expect(
-      chatsQuickProfileFirstUser.quickProfileUserImage
-    ).toBeDisplayed();
-    await expect(
-      chatsQuickProfileFirstUser.quickProfileBannerImage
-    ).toBeDisplayed();
-    await expect(
-      chatsQuickProfileFirstUser.quickProfileIndicatorOnline
-    ).toBeDisplayed();
+    await chatsQuickProfileFirstUser.quickProfileUserImage.waitForDisplayed();
+    await chatsQuickProfileFirstUser.quickProfileBannerImage.waitForDisplayed();
+    await chatsQuickProfileFirstUser.quickProfileIndicatorOnline.waitForDisplayed();
     await expect(
       chatsQuickProfileFirstUser.quickProfileUserNameValueText
     ).toHaveTextContaining("ChatUserB");
-    await expect(
-      chatsQuickProfileFirstUser.quickProfileRemoveFriend
-    ).toBeDisplayed();
-    await expect(
-      chatsQuickProfileFirstUser.quickProfileBlockUser
-    ).toBeDisplayed();
+    await chatsQuickProfileFirstUser.quickProfileRemoveFriend.waitForDisplayed();
+    await chatsQuickProfileFirstUser.quickProfileBlockUser.waitForDisplayed();
 
     // Click outside to close quick profile
     await chatsInputFirstUser.clickOnInputBar();

--- a/tests/specs/reusable-accounts/09-group-chats.spec.ts
+++ b/tests/specs/reusable-accounts/09-group-chats.spec.ts
@@ -42,10 +42,10 @@ export default async function groupChatTests() {
     await createGroupFirstUser.createGroupChatSection.waitForDisplayed();
 
     // Validate contents
-    await expect(createGroupFirstUser.groupNameInput).toBeDisplayed();
-    await expect(createGroupFirstUser.userSearchInput).toBeDisplayed();
-    await expect(createGroupFirstUser.friendsList).toBeDisplayed();
-    await expect(createGroupFirstUser.createGroupChatButton).toBeDisplayed();
+    await createGroupFirstUser.groupNameInput.waitForDisplayed();
+    await createGroupFirstUser.userSearchInput.waitForDisplayed();
+    await createGroupFirstUser.friendsList.waitForDisplayed();
+    await createGroupFirstUser.createGroupChatButton.waitForDisplayed();
   });
 
   it("Chat User A - Attempt to create group chat with alphanumeric chars in name", async () => {


### PR DESCRIPTION
### What this PR does 📖

- Noticed that some of the tests for Windows in CI are failing when using expect toBeDisplayed(), since the execution is happening really fast and elements are not being displayed, so I am changing these for waitForDisplayed() in order to give few seconds before failing tests due to that reason

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
