### PR TITLE
test(update): reducing timeouts on tests to ensure ci green

### DIFF
--- a/config/wdio.shared.conf.ts
+++ b/config/wdio.shared.conf.ts
@@ -106,6 +106,7 @@ export const config: WebdriverIO.Config = {
          * tests because they can take a bit longer.
          */
         timeout: 120000, // 2min
+        bail: true,
     },
     
     //

--- a/tests/screenobjects/chats/Messages.ts
+++ b/tests/screenobjects/chats/Messages.ts
@@ -337,7 +337,7 @@ export default class Messages extends UplinkMainScreen {
 
   async waitForMessageToBeDeleted(
     expectedMessage: string,
-    timeoutMsg: number = 60000
+    timeoutMsg: number = 30000
   ) {
     const currentDriver = await this.getCurrentDriver();
     if (currentDriver === MACOS_DRIVER) {
@@ -357,12 +357,11 @@ export default class Messages extends UplinkMainScreen {
 
   async waitForMessageSentToExist(
     expectedMessage: string,
-    timeoutMsg: number = 150000
+    timeoutMsg: number = 30000
   ) {
     const currentDriver = await this.getCurrentDriver();
     if (currentDriver === MACOS_DRIVER) {
       await this.instance
-        .$$(SELECTORS.CHAT_MESSAGE_LOCAL)
         .$(
           '//XCUIElementTypeStaticText[contains(@value, "' +
             expectedMessage +
@@ -378,7 +377,7 @@ export default class Messages extends UplinkMainScreen {
 
   async waitForReceivingMessage(
     expectedMessage: string,
-    timeoutMsg: number = 150000
+    timeoutMsg: number = 60000
   ) {
     const currentDriver = await this.getCurrentDriver();
     if (currentDriver === MACOS_DRIVER) {

--- a/tests/screenobjects/chats/Messages.ts
+++ b/tests/screenobjects/chats/Messages.ts
@@ -653,4 +653,122 @@ export default class Messages extends UplinkMainScreen {
       await rightClickOnWindows(messageToClick, this.executor);
     }
   }
+
+  // New message locators
+
+  async getFirstLocalMessage() {
+    const lastMessage = await this.chatMessageLocalFirst;
+    return lastMessage;
+  }
+
+  async getLastLocalMessage() {
+    const lastMessage = await this.chatMessageLocalLast;
+    return lastMessage;
+  }
+
+  async getFirstRemoteMessage() {
+    const lastMessage = await this.chatMessageRemoteFirst;
+    return lastMessage;
+  }
+
+  async getLastRemoteMessage() {
+    const lastMessage = await this.chatMessageRemoteLast;
+    return lastMessage;
+  }
+
+  async getMiddleLocalMessageLocator(
+    expectedMessage: string,
+    timeoutMsg: number = 30000
+  ) {
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === MACOS_DRIVER) {
+      await this.instance
+        .$(
+          '//Group[@label="message-local-message-middle"]//XCUIElementTypeStaticText[contains(@value, "' +
+            expectedMessage +
+            '")]/../..'
+        )
+        .waitForExist({ timeout: timeoutMsg });
+    } else if (currentDriver === WINDOWS_DRIVER) {
+      await this.instance
+        .$(
+          '//Group[@Name="message-local-message-middle"]//Text[contains(@Name, "' +
+            expectedMessage +
+            '")]/../..'
+        )
+        .waitForExist({ timeout: timeoutMsg });
+    }
+  }
+
+  async getMiddleRemoteMessageLocator(
+    expectedMessage: string,
+    timeoutMsg: number = 30000
+  ) {
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === MACOS_DRIVER) {
+      await this.instance
+        .$(
+          '//XCUIElementTypeGroup[@label="message-remote-message-middle"]//XCUIElementTypeStaticText[contains(@value, "' +
+            expectedMessage +
+            '")]/../..'
+        )
+        .waitForExist({ timeout: timeoutMsg });
+    } else if (currentDriver === WINDOWS_DRIVER) {
+      await this.instance
+        .$(
+          '//Group[@Name="message-remote-message-middle"]//Text[contains(@Name, "' +
+            expectedMessage +
+            '")]/../..'
+        )
+        .waitForExist({ timeout: timeoutMsg });
+    }
+  }
+
+  async waitForMessageRemoteToExist(
+    expectedMessage: string,
+    timeoutMsg: number = 30000
+  ) {
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === MACOS_DRIVER) {
+      await this.instance
+        .$(
+          '//XCUIElementTypeGroup[@label="message-remote-message-last"]//XCUIElementTypeStaticText[contains(@value, "' +
+            expectedMessage +
+            '")]'
+        )
+        .waitForExist({ timeout: timeoutMsg });
+    } else if (currentDriver === WINDOWS_DRIVER) {
+      await this.instance
+        .$(
+          '//Group[@Name="message-remote-message-last"]//Text[contains(@Name, "' +
+            expectedMessage +
+            '")]'
+        )
+        .waitForExist({ timeout: timeoutMsg });
+    }
+  }
+
+  async waitForMessageLocalToExist(
+    expectedMessage: string,
+    timeoutMsg: number = 30000
+  ) {
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === MACOS_DRIVER) {
+      await this.instance
+        .$(
+          '//XCUIElementTypeGroup[@label="message-local-message-last"]//XCUIElementTypeStaticText[contains(@value, "' +
+            expectedMessage +
+            '")]'
+        )
+        .waitForExist({ timeout: timeoutMsg });
+    } else if (currentDriver === WINDOWS_DRIVER) {
+      await this.instance
+        .$(
+          '//Group[@Name="message-local-message-last"]//Text[contains(@Name, "' +
+            expectedMessage +
+            '")]'
+        )
+        .waitForExist({ timeout: timeoutMsg });
+    }
+  }
 }

--- a/tests/screenobjects/friends/FriendsScreen.ts
+++ b/tests/screenobjects/friends/FriendsScreen.ts
@@ -644,7 +644,7 @@ export default class FriendsScreen extends UplinkMainScreen {
 
   async waitUntilFriendIsRemoved(
     username: string,
-    timeoutUser: number = 90000
+    timeoutUser: number = 60000
   ) {
     const currentDriver = await this.getCurrentDriver();
     if (currentDriver === MACOS_DRIVER) {

--- a/tests/specs/reusable-accounts/01-create-accounts-and-friends.spec.ts
+++ b/tests/specs/reusable-accounts/01-create-accounts-and-friends.spec.ts
@@ -252,7 +252,7 @@ export default async function createChatAccountsTests() {
 
     // Wait until Chat User A is online
     await chatsTopbarSecondUser.topbarIndicatorOnline.waitForDisplayed({
-      timeout: 240000,
+      timeout: 90000,
     });
   });
 

--- a/tests/specs/reusable-accounts/02-chat-replies.spec.ts
+++ b/tests/specs/reusable-accounts/02-chat-replies.spec.ts
@@ -85,7 +85,7 @@ export default async function repliesTests() {
 
     // With User A - Validate that reply message is received
     await chatsMessagesFirstUser.chatMessageReply.waitForDisplayed({
-      timeout: 180000,
+      timeout: 90000,
     });
   });
 

--- a/tests/specs/reusable-accounts/03-message-context-menu.spec.ts
+++ b/tests/specs/reusable-accounts/03-message-context-menu.spec.ts
@@ -50,7 +50,7 @@ export default async function messageContextMenuTests() {
     await chatsMessagesSecondUser.switchToOtherUserWindow();
 
     // With User B - Validate that last message is "edited"
-    await chatsMessagesSecondUser.waitForReceivingMessage("Edited...", 240000);
+    await chatsMessagesSecondUser.waitForReceivingMessage("Edited...", 60000);
 
     // With User B - Ensure that message "three.." was deleted
     await chatsMessagesSecondUser.waitForMessageToBeDeleted("Three...", 30000);

--- a/tests/specs/reusable-accounts/05-message-attachments.spec.ts
+++ b/tests/specs/reusable-accounts/05-message-attachments.spec.ts
@@ -15,13 +15,10 @@ export default async function messageAttachmentsTests() {
     // Click on upload button and attach a file to compose attachment
     await chatsInputFirstUser.uploadFile("./tests/fixtures/testfile.txt");
 
-    // Get the full path of file selected
-    const expectedPath = await chatsInputFirstUser.getFilePath(
-      "./tests/fixtures/testfile.txt"
-    );
-
     // Validate contents on Compose Attachments are displayed
-    await chatsAttachmentFirstUser.composeAttachmentsFileEmbed.waitForDisplayed();
+    await chatsAttachmentFirstUser.composeAttachmentsFileEmbed.waitForDisplayed(
+      { timeout: 30000 }
+    );
     await chatsAttachmentFirstUser.composeAttachmentsFileIcon.waitForDisplayed();
     await chatsAttachmentFirstUser.composeAttachmentsFileInfo.waitForDisplayed();
 

--- a/tests/specs/reusable-accounts/08-sidebar-chats.spec.ts
+++ b/tests/specs/reusable-accounts/08-sidebar-chats.spec.ts
@@ -190,7 +190,7 @@ export default async function sidebarChatsTests() {
     await chatsMessagesSecondUser.switchToOtherUserWindow();
 
     // With User B - Wait until message is received
-    await chatsMessagesSecondUser.waitForReceivingMessage("Hi...", 180000);
+    await chatsMessagesSecondUser.waitForReceivingMessage("Hi...", 60000);
   });
 
   it("Chat User B - Sidebar - Wait for receiving a a new message", async () => {

--- a/tests/specs/reusable-accounts/09-group-chats.spec.ts
+++ b/tests/specs/reusable-accounts/09-group-chats.spec.ts
@@ -128,7 +128,10 @@ export default async function groupChatTests() {
     await chatsInputFirstUser.clickOnSendMessage();
     await chatsInputFirstUser.typeMessageOnInput("test");
     await chatsInputFirstUser.clearInputBar();
-    await chatsMessagesFirstUser.waitForMessageSentToExist("Hi Group!");
+
+    // Validate text from message sent to the group
+    const textMessage = await chatsMessagesFirstUser.getLastMessageSentText();
+    await expect(textMessage).toHaveTextContaining("Hi Group!");
   });
 
   it("Group Chat - User B receives the message in group chat", async () => {

--- a/tests/specs/reusable-accounts/09-group-chats.spec.ts
+++ b/tests/specs/reusable-accounts/09-group-chats.spec.ts
@@ -126,6 +126,8 @@ export default async function groupChatTests() {
     await chatsInputFirstUser.switchToOtherUserWindow();
     await chatsInputFirstUser.typeMessageOnInput("Hi Group!");
     await chatsInputFirstUser.clickOnSendMessage();
+    await chatsInputFirstUser.typeMessageOnInput("test");
+    await chatsInputFirstUser.clearInputBar();
     await chatsMessagesFirstUser.waitForMessageSentToExist("Hi Group!");
   });
 

--- a/tests/specs/reusable-accounts/09-group-chats.spec.ts
+++ b/tests/specs/reusable-accounts/09-group-chats.spec.ts
@@ -124,20 +124,20 @@ export default async function groupChatTests() {
 
   it("Group Chat - User A sends a message in group chat", async () => {
     await chatsInputFirstUser.switchToOtherUserWindow();
-    await chatsInputFirstUser.typeMessageOnInput("Hi Group!");
+    await chatsInputFirstUser.typeMessageOnInput("HiGroup");
     await chatsInputFirstUser.clickOnSendMessage();
     await chatsInputFirstUser.typeMessageOnInput("test");
     await chatsInputFirstUser.clearInputBar();
 
     // Validate text from message sent to the group
     const textMessage = await chatsMessagesFirstUser.getLastMessageSentText();
-    await expect(textMessage).toHaveTextContaining("Hi Group!");
+    await expect(textMessage).toHaveTextContaining("HiGroup");
   });
 
   it("Group Chat - User B receives the message in group chat", async () => {
     await chatsLayoutSecondUser.switchToOtherUserWindow();
     await chatsSidebarSecondUser.goToSidebarGroupChat("Test");
-    await chatsMessagesSecondUser.waitForReceivingMessage("Hi Group!");
+    await chatsMessagesSecondUser.waitForReceivingMessage("HiGroup");
   });
 
   it("Group Chat - Show participants list - Contents", async () => {

--- a/tests/specs/reusable-accounts/11-group-chats-sidebar.spec.ts
+++ b/tests/specs/reusable-accounts/11-group-chats-sidebar.spec.ts
@@ -50,9 +50,9 @@ export default async function groupChatSidebarTests() {
   it("Group Chat - Send message to the group with User B", async () => {
     // Switch test execution control to User B and send message to the group
     await chatsTopbarSecondUser.switchToOtherUserWindow();
-    await chatsInputSecondUser.typeMessageOnInput("HelloGroup!");
+    await chatsInputSecondUser.typeMessageOnInput("HelloGroup");
     await chatsInputSecondUser.clickOnSendMessage();
-    await chatsMessagesSecondUser.waitForMessageSentToExist("HelloGroup!");
+    await chatsMessagesSecondUser.waitForMessageSentToExist("HelloGroup");
 
     // Switch control to User A
     await chatsLayoutFirstUser.switchToOtherUserWindow();
@@ -63,7 +63,7 @@ export default async function groupChatSidebarTests() {
     await chatsSidebarFirstUser.validateUsernameDisplayed("NewNameGroup");
 
     // Validate last message content from group is displayed on sidebar
-    await chatsSidebarFirstUser.validateLastMessageDisplayed("HelloGroup!");
+    await chatsSidebarFirstUser.validateLastMessageDisplayed("HelloGroup");
 
     // Validate number of unread messages from the group is displayed on sidebar
     await chatsSidebarFirstUser.validateNumberOfUnreadMessages("1");

--- a/tests/specs/reusable-accounts/SendMultipleMessages/03-send-several-messages-A.spec.ts
+++ b/tests/specs/reusable-accounts/SendMultipleMessages/03-send-several-messages-A.spec.ts
@@ -28,7 +28,7 @@ describe("Two users at the same time - Chat User A", async () => {
     await friendsScreenFirstUser.chatWithFriend("ChatUserB");
     await chatsLayoutFirstUser.waitForIsShown(true);
     await chatsTopbarFirstUser.topbarIndicatorOnline.waitForDisplayed({
-      timeout: 240000,
+      timeout: 60000,
     });
   });
 

--- a/tests/specs/reusable-accounts/SendMultipleMessages/04-send-several-messages-X.spec.ts
+++ b/tests/specs/reusable-accounts/SendMultipleMessages/04-send-several-messages-X.spec.ts
@@ -28,7 +28,7 @@ describe("Two users at the same time - Chat User A", async () => {
     await friendsScreenFirstUser.chatWithFriend("ChatUserA");
     await chatsLayoutFirstUser.waitForIsShown(true);
     await chatsTopbarFirstUser.topbarIndicatorOnline.waitForDisplayed({
-      timeout: 240000,
+      timeout: 60000,
     });
   });
 

--- a/tests/suites/Chats/01-Chats.suite.ts
+++ b/tests/suites/Chats/01-Chats.suite.ts
@@ -18,7 +18,7 @@ describe("Windows Chats Tests", function () {
   describe("Chat Replies Tests", repliesTests.bind(this));
   describe("Message Context Menu Tests", messageContextMenuTests.bind(this));
   describe("Message Input Tests", messageInputTests.bind(this));
-  /*describe("Message Attachments Tests", messageAttachmentsTests.bind(this));
+  describe("Message Attachments Tests", messageAttachmentsTests.bind(this));
   describe("Chat Tooltips Tests", chatTooltipsTests.bind(this));
   describe("Quick Profile Tests", quickProfileTests.bind(this));
   describe("Sidebar Chats Tests", sidebarChatsTests.bind(this));
@@ -27,5 +27,5 @@ describe("Windows Chats Tests", function () {
   describe(
     "Group Chats Favorites and Sidebar Tests",
     groupChatSidebarTests.bind(this)
-  );*/
+  );
 });


### PR DESCRIPTION
### What this PR does 📖

- I noticed that some of the timeout values from screenobject functions were using a timeout greater than the mocha timeout (2 minutes) and thats why when tests fail the screenshot was not attached because mocha timeout before the test actually failed. I am reducing the screenobject functions timeouts to ensure that a test fails before mocha fails and we can grab the screenshots from these failures
- Unskipping chat tests previously skipped for this

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
