### PR TITLE
test(update): skipping reaction tests and adding enable experimental

### DIFF
--- a/tests/screenobjects/settings/SettingsDeveloperScreen.ts
+++ b/tests/screenobjects/settings/SettingsDeveloperScreen.ts
@@ -60,14 +60,14 @@ export default class SettingsDeveloperScreen extends SettingsBaseScreen {
 
   get clearCacheDescription() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_SECTION)[5]
+      .$$(SELECTORS.SETTINGS_SECTION)[6]
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
   }
 
   get clearCacheHeader() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_SECTION)[5]
+      .$$(SELECTORS.SETTINGS_SECTION)[6]
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_HEADER);
   }
@@ -78,38 +78,64 @@ export default class SettingsDeveloperScreen extends SettingsBaseScreen {
 
   get compressAndDownloadCacheDescription() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_SECTION)[3]
+      .$$(SELECTORS.SETTINGS_SECTION)[4]
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
   }
 
   get compressAndDownloadCacheHeader() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_SECTION)[3]
+      .$$(SELECTORS.SETTINGS_SECTION)[4]
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_HEADER);
   }
 
   get developerModeCheckbox() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_CONTROL)[0]
+      .$$(SELECTORS.SETTINGS_CONTROL)[1]
       .$(SELECTORS.SWITCH_SLIDER);
   }
 
   get developerModeControllerValue() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_CONTROL)[0]
+      .$$(SELECTORS.SETTINGS_CONTROL)[1]
       .$(SELECTORS.SETTINGS_CONTROL_CHECKBOX);
   }
 
   get developerModeDescription() {
+    return this.instance
+      .$$(SELECTORS.SETTINGS_SECTION)[1]
+      .$(SELECTORS.SETTINGS_INFO)
+      .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
+  }
+
+  get developerModeHeader() {
+    return this.instance
+      .$$(SELECTORS.SETTINGS_SECTION)[1]
+      .$(SELECTORS.SETTINGS_INFO)
+      .$(SELECTORS.SETTINGS_INFO_HEADER);
+  }
+
+  get experimentalFeaturesCheckbox() {
+    return this.instance
+      .$$(SELECTORS.SETTINGS_CONTROL)[0]
+      .$(SELECTORS.SWITCH_SLIDER);
+  }
+
+  get experimentalFeaturesControllerValue() {
+    return this.instance
+      .$$(SELECTORS.SETTINGS_CONTROL)[0]
+      .$(SELECTORS.SETTINGS_CONTROL_CHECKBOX);
+  }
+
+  get experimentalFeaturesDescription() {
     return this.instance
       .$$(SELECTORS.SETTINGS_SECTION)[0]
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
   }
 
-  get developerModeHeader() {
+  get experimentalFeaturesHeader() {
     return this.instance
       .$$(SELECTORS.SETTINGS_SECTION)[0]
       .$(SELECTORS.SETTINGS_INFO)
@@ -122,14 +148,14 @@ export default class SettingsDeveloperScreen extends SettingsBaseScreen {
 
   get openCacheDescription() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_SECTION)[2]
+      .$$(SELECTORS.SETTINGS_SECTION)[3]
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
   }
 
   get openCacheHeader() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_SECTION)[2]
+      .$$(SELECTORS.SETTINGS_SECTION)[3]
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_HEADER);
   }
@@ -140,40 +166,40 @@ export default class SettingsDeveloperScreen extends SettingsBaseScreen {
 
   get printStateDescription() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_SECTION)[4]
+      .$$(SELECTORS.SETTINGS_SECTION)[5]
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
   }
 
   get printStateHeader() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_SECTION)[4]
+      .$$(SELECTORS.SETTINGS_SECTION)[5]
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_HEADER);
   }
 
   get saveLogsCheckbox() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_CONTROL)[6]
+      .$$(SELECTORS.SETTINGS_CONTROL)[7]
       .$(SELECTORS.SWITCH_SLIDER);
   }
 
   get saveLogsControllerValue() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_CONTROL)[6]
+      .$$(SELECTORS.SETTINGS_CONTROL)[7]
       .$(SELECTORS.SETTINGS_CONTROL_CHECKBOX);
   }
 
   get saveLogsDescription() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_SECTION)[6]
+      .$$(SELECTORS.SETTINGS_SECTION)[7]
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
   }
 
   get saveLogsHeader() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_SECTION)[6]
+      .$$(SELECTORS.SETTINGS_SECTION)[7]
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_HEADER);
   }
@@ -188,14 +214,14 @@ export default class SettingsDeveloperScreen extends SettingsBaseScreen {
 
   get testNotificationDescription() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_SECTION)[1]
+      .$$(SELECTORS.SETTINGS_SECTION)[2]
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
   }
 
   get testNotificationHeader() {
     return this.instance
-      .$$(SELECTORS.SETTINGS_SECTION)[1]
+      .$$(SELECTORS.SETTINGS_SECTION)[2]
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_HEADER);
   }

--- a/tests/specs/10-settings-developer.spec.ts
+++ b/tests/specs/10-settings-developer.spec.ts
@@ -12,6 +12,16 @@ export default async function settingsDeveloper() {
     await settingsNotificationsFirstUser.goToDeveloperSettings();
     await settingsDeveloperFirstUser.waitForIsShown(true);
 
+    // Validate EXPERIMENTAL FEATURES section
+    await expect(
+      settingsDeveloperFirstUser.experimentalFeaturesHeader
+    ).toHaveTextContaining("EXPERIMENTAL FEATURES");
+    await expect(
+      settingsDeveloperFirstUser.experimentalFeaturesDescription
+    ).toHaveTextContaining(
+      "Enables features which may be incomplete or non-functional."
+    );
+
     // Validate DEVELOPER MODE section
     await expect(
       settingsDeveloperFirstUser.developerModeHeader

--- a/tests/specs/reusable-accounts/03-message-context-menu.spec.ts
+++ b/tests/specs/reusable-accounts/03-message-context-menu.spec.ts
@@ -54,11 +54,12 @@ export default async function messageContextMenuTests() {
 
     // With User B - Ensure that message "three.." was deleted
     await chatsMessagesSecondUser.waitForMessageToBeDeleted("Three...", 30000);
-    await chatsInputFirstUser.switchToOtherUserWindow();
   });
 
-  it("Chat User A - React to sent message and multiple reactions in a message", async () => {
+  // Skipped because it needs rework due to latests changes on Reactions
+  xit("Chat User A - React to sent message and multiple reactions in a message", async () => {
     // React with heart emoji
+    await chatsInputFirstUser.switchToOtherUserWindow();
     await chatsMessagesFirstUser.openContextMenuOnLastSent();
     await chatsContextMenuFirstUser.validateContextMenuIsOpen();
     await chatsContextMenuFirstUser.selectContextOptionReact();
@@ -79,7 +80,8 @@ export default async function messageContextMenuTests() {
     await expect(reactions.includes("😍 1")).toEqual(true);
   });
 
-  it("Chat User A - React to received message", async () => {
+  // Skipped because it needs rework due to latests changes on Reactions
+  xit("Chat User A - React to received message", async () => {
     // React with cry emoji
     await chatsMessagesFirstUser.openContextMenuOnLastReceived();
     await chatsContextMenuFirstUser.validateContextMenuIsOpen();
@@ -93,7 +95,8 @@ export default async function messageContextMenuTests() {
     await expect(reaction.includes("😢 1")).toEqual(true);
   });
 
-  it("Chat User B - Receive reaction in sent message", async () => {
+  // Skipped because it needs rework due to latests changes on Reactions
+  xit("Chat User B - Receive reaction in sent message", async () => {
     // Return to Chat User B window
     await chatsInputSecondUser.switchToOtherUserWindow();
     await chatsInputSecondUser.clickOnInputBar();
@@ -106,7 +109,8 @@ export default async function messageContextMenuTests() {
     await expect(reaction.includes("😢 1")).toEqual(true);
   });
 
-  it("Chat User B - Receive reaction in received message", async () => {
+  // Skipped because it needs rework due to latests changes on Reactions
+  xit("Chat User B - Receive reaction in received message", async () => {
     // Validate reactions received on sent message
     const reactions =
       await chatsMessageGroupsSecondUser.getLastMessageReceivedRemoteReactions();
@@ -114,7 +118,8 @@ export default async function messageContextMenuTests() {
     await expect(reactions.includes("😍 1")).toEqual(true);
   });
 
-  it("Chat User B - Both users can react with the same emoji to a message", async () => {
+  // Skipped because it needs rework due to latests changes on Reactions
+  xit("Chat User B - Both users can react with the same emoji to a message", async () => {
     // React with cry emoji
     await chatsMessagesSecondUser.openContextMenuOnLastSent();
     await chatsContextMenuSecondUser.validateContextMenuIsOpen();
@@ -128,7 +133,8 @@ export default async function messageContextMenuTests() {
     await expect(reaction.includes("😢 2")).toEqual(true);
   });
 
-  it("Chat User B - Users can add a new reaction to a message already containing reactions", async () => {
+  // Skipped because it needs rework due to latests changes on Reactions
+  xit("Chat User B - Users can add a new reaction to a message already containing reactions", async () => {
     // React with 100 emoji
     await chatsMessagesSecondUser.openContextMenuOnLastSent();
     await chatsContextMenuSecondUser.validateContextMenuIsOpen();

--- a/tests/specs/reusable-accounts/04-message-input.spec.ts
+++ b/tests/specs/reusable-accounts/04-message-input.spec.ts
@@ -2,7 +2,6 @@ import { USER_A_INSTANCE, USER_B_INSTANCE } from "../../helpers/constants";
 import ChatsLayout from "../../screenobjects/chats/ChatsLayout";
 import InputBar from "../../screenobjects/chats/InputBar";
 import Messages from "../../screenobjects/chats/Messages";
-import chats from "../02-chats.spec";
 let chatsInputFirstUser = new InputBar(USER_A_INSTANCE);
 let chatsMessagesFirstUser = new Messages(USER_A_INSTANCE);
 let chatsMessagesSecondUser = new Messages(USER_B_INSTANCE);


### PR DESCRIPTION
### What this PR does 📖

- Updates to screenobject and spec file from Settings Developer to show the new Enable Experimental Features switch and setting text
- Skipping reaction tests that need rework after there were changes in the UI for these

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
