### PR TITLE
chore(appium): update settings for windows multiremote tests

### DIFF
--- a/config/wdio.windows.multiremote.conf.ts
+++ b/config/wdio.windows.multiremote.conf.ts
@@ -31,6 +31,11 @@ export const config: WebdriverIO.Config = {
     exclude: [
         // 'path/to/excluded/files'
     ],
+
+    // Default timeout for all waitFor* commands.
+    waitforTimeout: 15000,
+    // The number of times to retry the entire specfile when it fails as a whole
+    specFileRetries: 2,
     //
     // ============
     // Capabilities


### PR DESCRIPTION
### What this PR does 📖

- Updating setup for windows multiremote config file to do 2 retries in case of failing and wait for timeout increased to 15 seconds
### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
