### PR TITLE
test(update): fix for create folder issue on macos CI

### DIFF
--- a/tests/screenobjects/files/FilesScreen.ts
+++ b/tests/screenobjects/files/FilesScreen.ts
@@ -340,14 +340,10 @@ export default class FilesScreen extends UplinkMainScreen {
   }
 
   async createFolder(name: string) {
-    const currentDriver = await this.getCurrentDriver();
     await this.clickOnCreateFolder();
     await this.inputFolderFileName.click();
-    if (currentDriver === MACOS_DRIVER) {
-      await this.inputFolderFileName.setValue(name + "\n");
-    } else if (currentDriver === WINDOWS_DRIVER) {
-      await this.inputFolderFileName.setValue(name + "\uE007");
-    }
+    await this.inputFolderFileName.setValue(name);
+    await this.clickOnCreateFolder();
     const newFolder = await this.getLocatorOfFolderFile(name);
     await this.instance.$(newFolder).waitForExist({ timeout: 15000 });
   }


### PR DESCRIPTION
### What this PR does 📖

- There is one issue that is being presented often on CI for Files tests - Create a new folder and enter to it, so I am changing a bit the screenobject method to create a folder to not use the Enter key to save and instead of it, use the click on Create Folder button again

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
