### PR TITLE
test(add): negative friend request and welcome image tests

### DIFF
--- a/tests/helpers/constants.ts
+++ b/tests/helpers/constants.ts
@@ -1,3 +1,9 @@
+export const CHAT_USER_B_ID =
+  "did:key:z6Mksg6Q6uLs1s9LTd1EbUPh7idHDBqJ6dNss1BXcdd8BzCm";
+export const CHAT_USER_C_ID =
+  "did:key:z6MkrJ1upvw97WqetNm8nJ7xAPeTqUKZSunnRDzqSRQ6Fuh8";
+export const CHAT_USER_L_ID =
+  "did:key:z6Mkf4d6X4WwMoUw6hSf25aMuwm8CiL1mGxsfL96TTz4Pd6y";
 export const MACOS_BUNDLE_ID = "im.satellite.uplink";
 export const MACOS_USER_A_BUNDLE_ID = "im.satellite.uplinkChatUserA";
 export const MACOS_USER_B_BUNDLE_ID = "im.satellite.uplinkChatUserB";

--- a/tests/specs/02-chats.spec.ts
+++ b/tests/specs/02-chats.spec.ts
@@ -66,8 +66,16 @@ export default async function chats() {
     ).toHaveTextContaining("Settings");
   });
 
+  it("Welcome Screen - Welcome Image is displayed when no conversations are available", async () => {
+    await welcomeScreenFirstUser.welcomeImage.waitForExist();
+  });
+
   it("Click on add someone redirects to Friends Page", async () => {
     await welcomeScreenFirstUser.clickAddSomeone();
     await friendsScreenFirstUser.waitForIsShown(true);
+  });
+
+  it("Friends Screen - Image is displayed when no friends have been added yet", async () => {
+    await friendsScreenFirstUser.allFriendsListImage.waitForExist();
   });
 }

--- a/tests/specs/04-friends.spec.ts
+++ b/tests/specs/04-friends.spec.ts
@@ -4,7 +4,12 @@ import ChatsSidebar from "../screenobjects/chats/ChatsSidebar";
 import FavoritesSidebar from "../screenobjects/chats/FavoritesSidebar";
 import FriendsScreen from "../screenobjects/friends/FriendsScreen";
 import InputBar from "../screenobjects/chats/InputBar";
-import { USER_A_INSTANCE } from "../helpers/constants";
+import {
+  CHAT_USER_B_ID,
+  CHAT_USER_C_ID,
+  CHAT_USER_L_ID,
+  USER_A_INSTANCE,
+} from "../helpers/constants";
 import UplinkMainScreen from "../screenobjects/UplinkMainScreen";
 let chatsInputFirstUser = new InputBar(USER_A_INSTANCE);
 let chatsLayoutFirstUser = new ChatsLayout(USER_A_INSTANCE);
@@ -122,6 +127,22 @@ export default async function friends() {
       "Maximum of 56 characters exceeded."
     );
     await friendsScreenFirstUser.deleteAddFriendInput();
+  });
+
+  it("Add Friend Input - Attempt to send friend request to a user with outgoing pending request", async () => {
+    // Attempt to send a friend request to ChatUserL, who already received a not accepted yet friend request before
+    await friendsScreenFirstUser.enterFriendDidKey(CHAT_USER_L_ID);
+
+    // Wait for error toast notification with text "Friend request is already pending!" is gone
+    await friendsScreenFirstUser.waitUntilNotificationIsClosed();
+  });
+
+  it("Add Friend Input - Attempt to send friend request again to a user who is already your friend", async () => {
+    // Attempt to send a friend request to ChatUserB, who is already a friend
+    await friendsScreenFirstUser.enterFriendDidKey(CHAT_USER_B_ID);
+
+    // Wait for error toast notification with text "You are already friends!" is gone
+    await friendsScreenFirstUser.waitUntilNotificationIsClosed();
   });
 
   it("Switch to Pending Friends view and validate elements displayed", async () => {
@@ -254,6 +275,14 @@ export default async function friends() {
     const allFriendsList = await friendsScreenFirstUser.getAllFriendsList();
     const allListIncludesFriend = allFriendsList.includes(friendName);
     await expect(allListIncludesFriend).toEqual(false);
+  });
+
+  it("Add Friend Input - Attempt to send friend request to a blocked user", async () => {
+    // Attempt to send a friend request to ChatUserC, who was recently blocked
+    await friendsScreenFirstUser.enterFriendDidKey(CHAT_USER_C_ID);
+
+    // Wait for error toast notification with text "Key Blocked" is gone
+    await friendsScreenFirstUser.waitUntilNotificationIsClosed();
   });
 
   it("Validate tooltip for Deny Request button is displayed", async () => {


### PR DESCRIPTION
### What this PR does 📖

- Add test for attempting to send friend request to a user who is already a friend
- Add test for attempting to send friend request to a user who is in our outgoing requests list
- Add test for attempting to send friend request to a user who is in our blocked list
- Add test to validate image displayed on Main Screen when no conversations have been started yet
- Add test to validate image displayed on Friends Screen when no friends have been added yet

### Which issue(s) this PR fixes 🔨

- Resolve #165 #355 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
