### PR TITLE
chore(appium): update macos ci to use macos 13

### DIFF
--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-mac:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Checkout testing directory 🔖
         uses: actions/checkout@v3
@@ -131,7 +131,7 @@ jobs:
 
   test-mac:
     needs: build-mac
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
       - name: Checkout testing directory 🔖


### PR DESCRIPTION
### What this PR does 📖

- Update CI test workflow to use macos 13 instead of macos 12 (macos latest). In order to see if some random issues happening on mac are solved by using the latest OS version

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
