### PR TITLE
test(update): skip group chat tests failing for bug

### DIFF
--- a/tests/suites/Chats/01-Chats.suite.ts
+++ b/tests/suites/Chats/01-Chats.suite.ts
@@ -22,10 +22,10 @@ describe("Windows Chats Tests", function () {
   describe("Chat Tooltips Tests", chatTooltipsTests.bind(this));
   describe("Quick Profile Tests", quickProfileTests.bind(this));
   describe("Sidebar Chats Tests", sidebarChatsTests.bind(this));
-  describe("Group Chats Tests", groupChatTests.bind(this));
+  /*describe("Group Chats Tests", groupChatTests.bind(this));
   describe("Group Chats Edit Tests", groupChatEditTests.bind(this));
   describe(
     "Group Chats Favorites and Sidebar Tests",
     groupChatSidebarTests.bind(this)
-  );
+  );*/
 });


### PR DESCRIPTION
### What this PR does 📖

- Skipping Create Group Chat Tests for bug on opening Create Group modal is not focusing the screen on this modal

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
