### PR TITLE
chore(appium): attempt retry step action on macos ci

### DIFF
--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -193,7 +193,12 @@ jobs:
           cp -r ./tests/fixtures/users/FriendsTestUser/ ./tests/fixtures/users/mac2/FriendsTestUser
 
       - name: Run Tests on MacOS 🧪
-        run: npm run mac.ci
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 20
+          max_attempts: 2
+          shell:
+          command: npm run mac.ci
 
       - name: Upload Test Report - MacOS CI
         if: always()

--- a/config/wdio.mac.ci.conf.ts
+++ b/config/wdio.mac.ci.conf.ts
@@ -31,6 +31,8 @@ export const config: WebdriverIO.Config = {
     exclude: [
         // 'path/to/excluded/files'
     ],
+    // The number of times to retry the entire specfile when it fails as a whole
+    specFileRetries: 0,
     //
     // ============
     // Capabilities


### PR DESCRIPTION
### What this PR does 📖

- Use retry step action on CI job for MacOS automated tests, to avoid timeout cancel failing tests

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
