### PR TITLE
test(update): removing fifth recent reaction from tests

### DIFF
--- a/tests/screenobjects/chats/ContextMenu.ts
+++ b/tests/screenobjects/chats/ContextMenu.ts
@@ -131,10 +131,6 @@ export default class ContextMenu extends UplinkMainScreen {
     await this.emojiRecentFourth.click();
   }
 
-  async clickOnFifthReaction() {
-    await this.emojiRecentFifth.click();
-  }
-
   async clickOnRecentReactionButton(reaction: string) {
     const currentDriver = await this.getCurrentDriver();
     let locator;

--- a/tests/specs/reusable-accounts/03-message-context-menu.spec.ts
+++ b/tests/specs/reusable-accounts/03-message-context-menu.spec.ts
@@ -109,15 +109,15 @@ export default async function messageContextMenuTests() {
   });
 
   it("Chat User B - Users can add a new reaction to a message already containing reactions", async () => {
-    // React with ❤️ emoji
+    // React with 👍 emoji
     await chatsMessagesSecondUser.openContextMenuOnLastSent();
     await chatsContextMenuSecondUser.validateContextMenuIsOpen();
-    await chatsContextMenuSecondUser.clickOnFifthReaction();
+    await chatsContextMenuSecondUser.clickOnFourthReaction();
 
     // Validate reaction is displayed correctly
     const reaction =
       await chatsMessageGroupsSecondUser.getLastMessageSentSelfReactions();
     await expect(reaction.includes("👎 2")).toEqual(true);
-    await expect(reaction.includes("❤️ 1")).toEqual(true);
+    await expect(reaction.includes("👍 1")).toEqual(true);
   });
 }


### PR DESCRIPTION
### What this PR does 📖

- Remove fifth reaction from context menu - recent reactions, since now there are just four reactions used.

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
