### PR TITLE
chore(appium): use retry action for chats tests

### DIFF
--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -314,7 +314,7 @@ jobs:
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 30
-          max_attempts: 2
+          max_attempts: 3
           command: npm run windows.multiremote
 
       - name: Upload Test Report - Windows Chats

--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -311,7 +311,11 @@ jobs:
         shell: powershell
 
       - name: Run Chat Tests on Windows 🧪
-        run: npm run windows.multiremote
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          command: npm run windows.multiremote
 
       - name: Upload Test Report - Windows Chats
         if: always()

--- a/config/wdio.windows.multiremote.conf.ts
+++ b/config/wdio.windows.multiremote.conf.ts
@@ -34,7 +34,7 @@ export const config: WebdriverIO.Config = {
         // 'path/to/excluded/files'
     ],
     // The number of times to retry the entire specfile when it fails as a whole
-    specFileRetries: 2,
+    specFileRetries: 0,
     //
     // ============
     // Capabilities


### PR DESCRIPTION
### What this PR does 📖

- Using retry command on GH workflow to avoid connection issues on appium when running chats windows tests

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
