### PR TITLE
screenobject(update): fixing code input method to retry if appium fails

### DIFF
--- a/tests/screenobjects/chats/InputBar.ts
+++ b/tests/screenobjects/chats/InputBar.ts
@@ -203,20 +203,19 @@ export default class InputBar extends UplinkMainScreen {
 
   async typeCodeOnInputBar(language: string, codeToType: string) {
     const inputText = await this.inputText;
+    await inputText.clearValue();
     await inputText.addValue("```" + language);
-    await robot.keyTap("enter", ["shift"]);
-    await inputText.addValue(codeToType);
-    await inputText.waitUntil(
-      async () => {
-        const inputTextValue = await inputText.getText();
-        return await inputTextValue.includes(codeToType);
-      },
-      {
-        timeout: 5000,
-        timeoutMsg:
-          "Expected chat input to contain code markdown text after 5 seconds",
+    const inputTextValueLanguage = await inputText.getText();
+    if (inputTextValueLanguage.includes("```" + language) === false) {
+      await this.typeCodeOnInputBar(language, codeToType);
+    } else {
+      await robot.keyTap("enter", ["shift"]);
+      await inputText.addValue(codeToType);
+      const inputTextValueCode = await inputText.getText();
+      if (inputTextValueCode.includes(codeToType) === false) {
+        await this.typeCodeOnInputBar(language, codeToType);
       }
-    );
+    }
   }
 
   async typeMessageOnInput(text: string) {


### PR DESCRIPTION
### What this PR does 📖

- Retry code input if language input was typed incorrectly by Appium
- Retry code input if code sentence was typed incorrectly by Appium
- In order to avoid failures in tests for code typed not as expected
- Test will timeout at 120 seconds in case that code typing was never done correctly

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
