### PR TITLE
test(update): wait for toast notifications to be closed before interact

### DIFF
--- a/tests/screenobjects/chats/MessageGroup.ts
+++ b/tests/screenobjects/chats/MessageGroup.ts
@@ -228,10 +228,19 @@ export default class MessageGroup extends UplinkMainScreen {
 
   async getLastGroupWrapReceivedOnline() {
     const groupWrap = await this.getLastGroupWrapReceived();
+    await driver[this.executor].waitUntil(
+      async () => {
+        return await groupWrap.$(SELECTORS.MESSAGE_GROUP_USER_INDICATOR_ONLINE);
+      },
+      {
+        timeout: 15000,
+        timeoutMsg:
+          "Expected indicator online on last message group received was never displayed after 15 seconds",
+      }
+    );
     const onlineStatus = await groupWrap.$(
       SELECTORS.MESSAGE_GROUP_USER_INDICATOR_ONLINE
     );
-    await onlineStatus.waitForExist();
     return onlineStatus;
   }
 
@@ -255,10 +264,20 @@ export default class MessageGroup extends UplinkMainScreen {
 
   async getLastGroupWrapSentOnline() {
     const groupWrap = await this.getLastGroupWrapSent();
+    await driver[this.executor].waitUntil(
+      async () => {
+        return await groupWrap.$(SELECTORS.MESSAGE_GROUP_USER_INDICATOR_ONLINE);
+      },
+      {
+        timeout: 15000,
+        timeoutMsg:
+          "Expected indicator online on last message group sent was never displayed after 15 seconds",
+      }
+    );
+
     const onlineStatus = await groupWrap.$(
       SELECTORS.MESSAGE_GROUP_USER_INDICATOR_ONLINE
     );
-    await onlineStatus.waitForExist();
     return onlineStatus;
   }
 

--- a/tests/specs/05-settings-profile.spec.ts
+++ b/tests/specs/05-settings-profile.spec.ts
@@ -72,42 +72,8 @@ export default async function settingsProfile() {
     await expect(statusInput).toHaveTextContaining("");
   });
 
-  it("Settings Profile - Validate Copy ID button tooltip", async () => {
-    // Validate Copy ID button tooltip
-    await settingsProfileFirstUser.hoverOnCopyID();
-
-    await settingsProfileFirstUser.copyIDTooltip.waitForExist();
-
-    const copyIDTooltipText = await settingsProfileFirstUser.copyIDTooltipText;
-    await expect(copyIDTooltipText).toHaveTextContaining("Copy ID");
-  });
-
-  it("Settings Profile - Click On Copy ID Button", async () => {
-    // Click on Copy ID button and assert Toast Notification is displayed
-    await settingsProfileFirstUser.clickOnCopyIDButton();
-
-    // Wait for toast notification to be closed
-    await settingsProfileFirstUser.waitUntilNotificationIsClosed();
-  });
-
-  it("Settings Profile - Copied ID can be placed on any text field", async () => {
-    // Paste copied DID Key into Status Input
-    await settingsProfileFirstUser.pasteUserKeyInStatus();
-
-    // Ensure that value placed in Status is the did key from the user
-    const statusInputText =
-      await settingsProfileFirstUser.getStatusInputElement();
-    await expect(statusInputText).toHaveTextContaining("did:key:");
-
-    // Clear value from status input
-    await settingsProfileFirstUser.deleteStatus();
-  });
-
   // Needs visual validation steps to ensure that picture was actually loaded matches with expected image
   it("Settings Profile - Add profile picture", async () => {
-    // Wait for toast notification to be closed before starting test
-    await settingsProfileFirstUser.waitUntilNotificationIsClosed();
-
     await settingsProfileFirstUser.uploadProfilePicture(
       "./tests/fixtures/logo.jpg"
     );
@@ -152,6 +118,40 @@ export default async function settingsProfile() {
     await settingsProfileFirstUser.uploadBannerPicture(
       "./tests/fixtures/second-banner.jpg"
     );
+  });
+
+  it("Settings Profile - Validate Copy ID button tooltip", async () => {
+    // Wait for toast notification to be closed before starting test
+    await settingsProfileFirstUser.waitUntilNotificationIsClosed();
+
+    // Validate Copy ID button tooltip
+    await settingsProfileFirstUser.hoverOnCopyID();
+
+    await settingsProfileFirstUser.copyIDTooltip.waitForExist();
+
+    const copyIDTooltipText = await settingsProfileFirstUser.copyIDTooltipText;
+    await expect(copyIDTooltipText).toHaveTextContaining("Copy ID");
+  });
+
+  it("Settings Profile - Click On Copy ID Button", async () => {
+    // Click on Copy ID button and assert Toast Notification is displayed
+    await settingsProfileFirstUser.clickOnCopyIDButton();
+
+    // Wait for toast notification to be closed
+    await settingsProfileFirstUser.waitUntilNotificationIsClosed();
+  });
+
+  it("Settings Profile - Copied ID can be placed on any text field", async () => {
+    // Paste copied DID Key into Status Input
+    await settingsProfileFirstUser.pasteUserKeyInStatus();
+
+    // Ensure that value placed in Status is the did key from the user
+    const statusInputText =
+      await settingsProfileFirstUser.getStatusInputElement();
+    await expect(statusInputText).toHaveTextContaining("did:key:");
+
+    // Clear value from status input
+    await settingsProfileFirstUser.deleteStatus();
   });
 
   it("Settings Profile - Status with more than 128 characters", async () => {

--- a/tests/specs/05-settings-profile.spec.ts
+++ b/tests/specs/05-settings-profile.spec.ts
@@ -105,12 +105,18 @@ export default async function settingsProfile() {
 
   // Needs visual validation steps to ensure that picture was actually loaded matches with expected image
   it("Settings Profile - Add profile picture", async () => {
+    // Wait for toast notification to be closed before starting test
+    await settingsProfileFirstUser.waitUntilNotificationIsClosed();
+
     await settingsProfileFirstUser.uploadProfilePicture(
       "./tests/fixtures/logo.jpg"
     );
   });
 
   it("Settings Profile - Validate change banner tooltip", async () => {
+    // Wait for toast notification to be closed
+    await settingsProfileFirstUser.waitUntilNotificationIsClosed();
+
     // Hover on banner picture
     await settingsProfileFirstUser.hoverOnBanner();
 
@@ -126,12 +132,13 @@ export default async function settingsProfile() {
     await settingsProfileFirstUser.uploadBannerPicture(
       "./tests/fixtures/banner.jpg"
     );
-
-    await settingsProfileFirstUser.usernameInput.waitForExist();
   });
 
   // Needs visual validation steps to ensure that picture was actually loaded matches with expected image
   it("Settings Profile - Change profile picture", async () => {
+    // Wait for toast notification to be closed before starting test
+    await settingsProfileFirstUser.waitUntilNotificationIsClosed();
+
     await settingsProfileFirstUser.uploadProfilePicture(
       "./tests/fixtures/second-profile.png"
     );
@@ -139,12 +146,18 @@ export default async function settingsProfile() {
 
   // Needs visual validation steps to ensure that picture was actually loaded matches with expected image
   it("Settings Profile - Change banner picture", async () => {
+    // Wait for toast notification to be closed before starting test
+    await settingsProfileFirstUser.waitUntilNotificationIsClosed();
+
     await settingsProfileFirstUser.uploadBannerPicture(
       "./tests/fixtures/second-banner.jpg"
     );
   });
 
   it("Settings Profile - Status with more than 128 characters", async () => {
+    // Wait for toast notification to be closed before starting test
+    await settingsProfileFirstUser.waitUntilNotificationIsClosed();
+
     // Enter status value with more than 128 characters
     await settingsProfileFirstUser.enterStatus(
       "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
@@ -161,6 +174,9 @@ export default async function settingsProfile() {
   });
 
   it("Settings Profile - Username with less than 4 characters", async () => {
+    // Wait for toast notification to be closed before starting test
+    await settingsProfileFirstUser.waitUntilNotificationIsClosed();
+
     // Enter username value with less than 4 characters
     await settingsProfileFirstUser.enterUsername("123");
     // Validate that error message is displayed
@@ -175,6 +191,9 @@ export default async function settingsProfile() {
   });
 
   it("Settings Profile - Username - Spaces are not allowed", async () => {
+    // Wait for toast notification to be closed before starting test
+    await settingsProfileFirstUser.waitUntilNotificationIsClosed();
+
     // Enter username value with spaces
     await settingsProfileFirstUser.enterUsername("1234" + "             ");
     // Validate that error message is displayed
@@ -189,6 +208,9 @@ export default async function settingsProfile() {
   });
 
   it("Settings Profile - Username with non-alphanumeric characters", async () => {
+    // Wait for toast notification to be closed before starting test
+    await settingsProfileFirstUser.waitUntilNotificationIsClosed();
+
     // Enter username value with non-alphanumeric characters
     await settingsProfileFirstUser.enterUsername("test&^%*%#$");
     // Validate that error message is displayed
@@ -204,6 +226,9 @@ export default async function settingsProfile() {
   });
 
   it("Settings Profile - Username with more than 32 characters", async () => {
+    // Wait for toast notification to be closed before starting test
+    await settingsProfileFirstUser.waitUntilNotificationIsClosed();
+
     // Enter username value with more than 32 characters
     await settingsProfileFirstUser.enterUsername(
       "12345678901234567890123456789012345"
@@ -217,5 +242,8 @@ export default async function settingsProfile() {
 
     // Clear value from username input, then enter a valid value again
     await settingsProfileFirstUser.enterUsername("Test123");
+
+    // Wait for toast notification to be closed before starting next tests
+    await settingsProfileFirstUser.waitUntilNotificationIsClosed();
   });
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Wait for toast notifications on profile updated are gone before doing any validations to avoid random issues presented when trying to interact with elements when the notification is still present

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
