### PR TITLE
test(add): send files on chat through browse files

### DIFF
--- a/tests/screenobjects/chats/InputBar.ts
+++ b/tests/screenobjects/chats/InputBar.ts
@@ -205,6 +205,11 @@ export default class InputBar extends UplinkMainScreen {
     await uploadButtonLocalDisk.click();
   }
 
+  async selectUploadFromStorage() {
+    const uploadButtonStorage = await this.uploadButtonStorage;
+    await uploadButtonStorage.click();
+  }
+
   async typeCodeOnInputBar(language: string, codeToType: string) {
     const inputText = await this.inputText;
     await inputText.clearValue();
@@ -245,5 +250,10 @@ export default class InputBar extends UplinkMainScreen {
       await this.selectUploadFromLocalDisk();
       await selectFileOnWindows(relativePath, uplinkContext, executor);
     }
+  }
+
+  async openUploadFilesFromStorage() {
+    await this.clickOnUploadFile();
+    await this.selectUploadFromStorage();
   }
 }

--- a/tests/screenobjects/chats/Messages.ts
+++ b/tests/screenobjects/chats/Messages.ts
@@ -300,10 +300,10 @@ export default class Messages extends UplinkMainScreen {
 
   async getLastMessageReceivedCodeLanguage() {
     const message = await this.getLastMessageReceivedLocator();
-    const messageCodeLanguage = await message
-      .$(SELECTORS.CHAT_MESSAGE_TEXT_GROUP)
-      .$(SELECTORS.CHAT_MESSAGE_CODE_LANGUAGE);
-    await messageCodeLanguage.waitForExist();
+    const messageText = await message.$(SELECTORS.CHAT_MESSAGE_TEXT_GROUP);
+    const messageCodeLanguage = await messageText.$(
+      SELECTORS.CHAT_MESSAGE_CODE_LANGUAGE
+    );
     return messageCodeLanguage;
   }
 
@@ -592,9 +592,10 @@ export default class Messages extends UplinkMainScreen {
 
   async getLastMessageSentCodeLanguage() {
     const message = await this.getLastMessageSentLocator();
-    const messageCodeLanguage = await message
-      .$(SELECTORS.CHAT_MESSAGE_TEXT_GROUP)
-      .$(SELECTORS.CHAT_MESSAGE_CODE_LANGUAGE);
+    const messageText = await message.$(SELECTORS.CHAT_MESSAGE_TEXT_GROUP);
+    const messageCodeLanguage = await messageText.$(
+      SELECTORS.CHAT_MESSAGE_CODE_LANGUAGE
+    );
     await messageCodeLanguage.waitForExist();
     return messageCodeLanguage;
   }
@@ -799,7 +800,7 @@ export default class Messages extends UplinkMainScreen {
     const lastMessageLinkEmbed = await lastMessage.$(
       SELECTORS.CHAT_MESSAGE_LINK_EMBED
     );
-    await lastMessageLinkEmbed.waitForExist();
+    await lastMessageLinkEmbed.waitForExist({ timeout: 30000 });
     return lastMessageLinkEmbed;
   }
 
@@ -836,7 +837,7 @@ export default class Messages extends UplinkMainScreen {
     const lastMessageLinkEmbed = await lastMessage.$(
       SELECTORS.CHAT_MESSAGE_LINK_EMBED
     );
-    await lastMessageLinkEmbed.waitForExist();
+    await lastMessageLinkEmbed.waitForExist({ timeout: 30000 });
     return lastMessageLinkEmbed;
   }
 

--- a/tests/screenobjects/chats/SendFiles.ts
+++ b/tests/screenobjects/chats/SendFiles.ts
@@ -168,7 +168,9 @@ export default class SendFiles extends UplinkMainScreen {
 
   async clickOnFileOrFolder(locator: string) {
     const fileOrFolderLocator = await this.getLocatorOfFolderFile(locator);
-    const fileOrFolderElement = await this.instance.$(fileOrFolderLocator);
+    const fileOrFolderElement = await this.instance
+      .$(fileOrFolderLocator)
+      .$(SELECTORS.FILE_THUMBNAIL);
     await fileOrFolderElement.click();
   }
 

--- a/tests/screenobjects/chats/SendFiles.ts
+++ b/tests/screenobjects/chats/SendFiles.ts
@@ -13,6 +13,8 @@ let SELECTORS = {};
 const SELECTORS_COMMON = {};
 
 const SELECTORS_WINDOWS = {
+  CLOSE_BUTTON: "<Button>",
+  CLOSE_BUTTON_MODAL: '[name="modal"]',
   CONTEXT_MENU: '[name="Context Menu"]',
   CONTEXT_MENU_FILES_RENAME: '[name="files-rename"]',
   CONTEXT_MENU_FOLDER_DELETE: '[name="folder-delete"]',
@@ -36,6 +38,8 @@ const SELECTORS_WINDOWS = {
 };
 
 const SELECTORS_MACOS = {
+  CLOSE_BUTTON: "-ios class chain:**/XCUIElementTypeButton",
+  CLOSE_BUTTON_MODAL: "~modal",
   CONTEXT_MENU: "~Context Menu",
   CONTEXT_MENU_FILES_RENAME: "~files-rename",
   CONTEXT_MENU_FOLDER_DELETE: "~folder-delete",
@@ -67,6 +71,14 @@ currentOS === WINDOWS_DRIVER
 export default class SendFiles extends UplinkMainScreen {
   constructor(executor: string) {
     super(executor, SELECTORS.SEND_FILES_LAYOUT);
+  }
+
+  get closeButton() {
+    return this.closeButtonModal.$(SELECTORS.CLOSE_BUTTON);
+  }
+
+  get closeButtonModal() {
+    return this.instance.$(SELECTORS.CLOSE_BUTTON_MODAL);
   }
 
   get contextMenu() {
@@ -147,6 +159,11 @@ export default class SendFiles extends UplinkMainScreen {
 
   get sendFilesModalSendButton() {
     return this.sendFilesBody.$(SELECTORS.SEND_FILES_MODAL_SEND_BUTTON);
+  }
+
+  async clickOnCloseModal() {
+    const closeButton = await this.closeButton;
+    await closeButton.click();
   }
 
   async clickOnFileOrFolder(locator: string) {

--- a/tests/screenobjects/files/FilesScreen.ts
+++ b/tests/screenobjects/files/FilesScreen.ts
@@ -363,6 +363,12 @@ export default class FilesScreen extends UplinkMainScreen {
     const filesInfoCurrentSizeLabel = await this.filesInfoCurrentSizeLabel;
     await inputFolderFileName.waitForExist();
     await inputFolderFileName.setValue(name);
+    // Retry typing if appium fails on type
+    const inputValue = await inputFolderFileName.getText();
+    if (inputValue !== name) {
+      await this.createFolder(name);
+    }
+    // If name was typed correctly, continue with method execution
     await filesInfoCurrentSizeLabel.click();
     const newFolder = await this.getLocatorOfFolderFile(name);
     const newFolderElement = await this.instance.$(newFolder);

--- a/tests/specs/reusable-accounts/05-message-attachments.spec.ts
+++ b/tests/specs/reusable-accounts/05-message-attachments.spec.ts
@@ -1,16 +1,138 @@
 import "module-alias/register";
 import { USER_A_INSTANCE, USER_B_INSTANCE } from "@helpers/constants";
 import ComposeAttachment from "@screenobjects/chats/ComposeAttachment";
+import FilesScreen from "@screenobjects/files/FilesScreen";
 import InputBar from "@screenobjects/chats/InputBar";
 import Messages from "@screenobjects/chats/Messages";
+import SendFiles from "@screenobjects/chats/SendFiles";
 let chatsAttachmentFirstUser = new ComposeAttachment(USER_A_INSTANCE);
 let chatsAttachmentSecondUser = new ComposeAttachment(USER_B_INSTANCE);
 let chatsInputFirstUser = new InputBar(USER_A_INSTANCE);
 let chatsInputSecondUser = new InputBar(USER_B_INSTANCE);
 let chatsMessagesFirstUser = new Messages(USER_A_INSTANCE);
 let chatsMessagesSecondUser = new Messages(USER_B_INSTANCE);
+let filesScreenSecondUser = new FilesScreen(USER_B_INSTANCE);
+let sendFilesSecondUser = new SendFiles(USER_B_INSTANCE);
 
 export default async function messageAttachmentsTests() {
+  it("Send files from Browse Files - No files are displayed on modal and user can close modal", async () => {
+    // Go to upload button and then select Browser Files (from Uplink storage)
+    await chatsInputSecondUser.openUploadFilesFromStorage();
+    await sendFilesSecondUser.validateSendFilesModalIsShown();
+    await sendFilesSecondUser.validateNoFilesAvailableIsShown();
+
+    // Click outside of the modal to close it, in this case on the send message button
+    await chatsInputSecondUser.clickOnSendMessage();
+  });
+
+  it("Send files from Browse Files - Upload an image on Files to run tests", async () => {
+    // Go to Files Screen andand upload an image file before starting
+    await chatsInputSecondUser.goToFiles();
+    await filesScreenSecondUser.validateFilesScreenIsShown();
+    await filesScreenSecondUser.uploadFile("./tests/fixtures/logo.jpg");
+    await filesScreenSecondUser.validateFileOrFolderExist("logo.jpg");
+  });
+
+  it("Send files from Browse Files - Upload a txt file in a different folder", async () => {
+    // Create a new folder and enter on it
+    await filesScreenSecondUser.createFolder("testfolder01");
+    await filesScreenSecondUser.validateFileOrFolderExist("testfolder01");
+    await filesScreenSecondUser.clickOnFileOrFolder("testfolder01");
+
+    // Upload one time the testfile.txt file
+    await filesScreenSecondUser.uploadFile("./tests/fixtures/testfile.txt");
+    await filesScreenSecondUser.validateFileOrFolderExist("testfile.txt");
+
+    // Return to chat screen
+    await filesScreenSecondUser.goToMainScreen();
+  });
+
+  it("Send files from Browse Files - Thumbnails are displayed on modal", async () => {
+    // Open modal to send files from storage
+    await chatsInputSecondUser.openUploadFilesFromStorage();
+    await sendFilesSecondUser.validateSendFilesModalIsShown();
+
+    // Go to Home Folder and validate thumbnail for file is shown
+    await sendFilesSecondUser.clickOnHomeFolderCrumb();
+    await filesScreenSecondUser.validateFileOrFolderExist("logo.jpg");
+    await sendFilesSecondUser.validateThumbnailIsShown("logo.jpg");
+  });
+
+  it("Send files from Browse Files - User can navigate through folders and to home", async () => {
+    // Navigate to testfolder01 and ensure thumbnail from testfile.txt is shown
+    await sendFilesSecondUser.clickOnFileOrFolder("testfolder01");
+    await filesScreenSecondUser.validateFileOrFolderExist("testfile.txt");
+    await sendFilesSecondUser.validateThumbnailIsShown("testfile.txt");
+
+    // Navigate to home folder and ensure thumbnail from logo.jpg is shown
+    await sendFilesSecondUser.clickOnHomeFolderCrumb();
+    await filesScreenSecondUser.validateFileOrFolderExist("logo.jpg");
+    await sendFilesSecondUser.validateThumbnailIsShown("logo.jpg");
+  });
+
+  // Skipped since there is a bug reported for this functionality that it is not solved yet
+  xit("Send files from Browse Files - Go to files button redirects to Files", async () => {
+    // Click on Go To Files button and validate User is redirected to Files Screen
+    await sendFilesSecondUser.clickOnGoToFiles();
+    await filesScreenSecondUser.validateFilesScreenIsShown();
+
+    // Return to Chat Screen and open again the Send Files from Storage modal
+    await filesScreenSecondUser.goToMainScreen();
+    await chatsInputSecondUser.openUploadFilesFromStorage();
+    await sendFilesSecondUser.validateSendFilesModalIsShown();
+  });
+
+  it("Send files from Browse Files - Send files button displays number of files selected", async () => {
+    // When no files are selected, Send Files button should display 0/8 File(s)
+    await sendFilesSecondUser.validateSendFilesButtonText("Send 0/8 File(s)");
+
+    // Select one file and ensure Send Files button should display10/8 File(s)
+    await sendFilesSecondUser.clickOnFileOrFolder("logo.jpg");
+    await sendFilesSecondUser.validateSendFilesButtonText("Send 1/8 File(s)");
+
+    // Unselect the file previously selected and ensure Send Files button displays 0/8 File(s) again
+    await sendFilesSecondUser.clickOnFileOrFolder("logo.jpg");
+    await sendFilesSecondUser.validateSendFilesButtonText("Send 0/8 File(s)");
+  });
+
+  xit("Send files from Browse Files - User can select files to send from multiple folders", async () => {
+    // Pending work to be done here
+  });
+
+  // Skipped since there is a bug reported for this test
+  xit("Send files from Browse Files - User cannot click on send files if no files are selected", async () => {
+    // Click on Send files button without any files selected
+    await sendFilesSecondUser.clickOnSendFilesButton();
+
+    // Ensure that Send Files Modal is still displayed
+    await sendFilesSecondUser.validateSendFilesModalIsShown();
+  });
+
+  it("Send files from Browse Files - Files selected will be displayed on Compose Attachment", async () => {
+    // Remove the files previously selected
+    await sendFilesSecondUser.clickOnFileOrFolder("logo.jpg");
+
+    // Send the files selected
+    await sendFilesSecondUser.clickOnSendFilesButton();
+
+    // Validate files displayed on Compose Attachment
+    // Validate compose attachments displays the files to be uploaded before sending the message
+    await chatsAttachmentSecondUser.validateComposeAttachmentsIsShown();
+
+    // Obtain the list of attachments added to Compose Attachment
+    await chatsAttachmentSecondUser.validateAttachmentWithFileNameIsAdded(
+      "logo.jpg",
+      true
+    );
+
+    // Click on delete compose attachment
+    await chatsAttachmentSecondUser.deleteFileOnComposeAttachment();
+  });
+
+  xit("Send files from Browse Files - Message sent with attachments is shown on local and remote side", async () => {
+    // Pending work to be done here
+  });
+
   it("Chat User B - Validate compose attachments contents", async () => {
     // Switch to User B window
     await chatsInputSecondUser.switchToOtherUserWindow();

--- a/tests/specs/reusable-accounts/05-message-attachments.spec.ts
+++ b/tests/specs/reusable-accounts/05-message-attachments.spec.ts
@@ -81,24 +81,12 @@ export default async function messageAttachmentsTests() {
     await sendFilesSecondUser.validateSendFilesModalIsShown();
   });
 
-  it("Send files from Browse Files - Send files button displays number of files selected", async () => {
+  it("Send files from Browse Files - Send files button shows 0/8 files if no files are selected", async () => {
     // When no files are selected, Send Files button should display 0/8 File(s)
     await sendFilesSecondUser.validateSendFilesButtonText("Send 0/8 File(s)");
-
-    // Select one file and ensure Send Files button should display10/8 File(s)
-    await sendFilesSecondUser.clickOnFileOrFolder("logo.jpg");
-    await sendFilesSecondUser.validateSendFilesButtonText("Send 1/8 File(s)");
-
-    // Unselect the file previously selected and ensure Send Files button displays 0/8 File(s) again
-    await sendFilesSecondUser.clickOnFileOrFolder("logo.jpg");
-    await sendFilesSecondUser.validateSendFilesButtonText("Send 0/8 File(s)");
   });
 
-  xit("Send files from Browse Files - User can select files to send from multiple folders", async () => {
-    // Pending work to be done here
-  });
-
-  // Skipped since there is a bug reported for this test
+  // Skipped since there is a bug reported for this button
   xit("Send files from Browse Files - User cannot click on send files if no files are selected", async () => {
     // Click on Send files button without any files selected
     await sendFilesSecondUser.clickOnSendFilesButton();
@@ -107,14 +95,29 @@ export default async function messageAttachmentsTests() {
     await sendFilesSecondUser.validateSendFilesModalIsShown();
   });
 
-  it("Send files from Browse Files - Files selected will be displayed on Compose Attachment", async () => {
-    // Remove the files previously selected
+  it("Send files from Browse Files - Can select files from different folders and send files counter is updated", async () => {
+    // Select one file from root folder and ensure Send Files button displays 1/8 File(s)
     await sendFilesSecondUser.clickOnFileOrFolder("logo.jpg");
+    await sendFilesSecondUser.validateSendFilesButtonText("Send 1/8 File(s)");
 
-    // Send the files selected
+    // Go to testfolder01 and select one file from this folder
+    await sendFilesSecondUser.clickOnFileOrFolder("testfolder01");
+    await filesScreenSecondUser.validateFileOrFolderExist("testfile.txt");
+    await sendFilesSecondUser.clickOnFileOrFolder("testfile.txt");
+
+    // Ensure Send Files button displays 2/8 File(s)
+    await sendFilesSecondUser.validateSendFilesButtonText("Send 2/8 File(s)");
+
+    // Remove selection from file and valiate Send Files button displays 1/8 File(s)
+    await sendFilesSecondUser.clickOnFileOrFolder("testfile.txt");
+    await sendFilesSecondUser.validateSendFilesButtonText("Send 1/8 File(s)");
+  });
+
+  it("Send files from Browse Files - Files selected will be displayed on Compose Attachment", async () => {
+    // Send the only image file previously selected
     await sendFilesSecondUser.clickOnSendFilesButton();
 
-    // Validate files displayed on Compose Attachment
+    // Validate file is displayed on Compose Attachment
     // Validate compose attachments displays the files to be uploaded before sending the message
     await chatsAttachmentSecondUser.validateComposeAttachmentsIsShown();
 
@@ -123,13 +126,33 @@ export default async function messageAttachmentsTests() {
       "logo.jpg",
       true
     );
-
-    // Click on delete compose attachment
-    await chatsAttachmentSecondUser.deleteFileOnComposeAttachment();
   });
 
-  xit("Send files from Browse Files - Message sent with attachments is shown on local and remote side", async () => {
-    // Pending work to be done here
+  it("Send files from Browse Files - Message sent with attachments is shown on local side", async () => {
+    // Type a text message and send it
+    await chatsInputSecondUser.typeMessageOnInput("Attached");
+    await chatsInputSecondUser.clickOnSendMessage();
+
+    // Ensure that message sent with attached file is displayed on local side
+    await chatsMessagesSecondUser.waitForMessageSentToExist("Attached");
+
+    await chatsMessagesSecondUser.chatMessageFileEmbedLocal.waitForExist();
+
+    // Validate text from message containing attachment
+    const textMessage = await chatsMessagesSecondUser.getLastMessageSentText();
+    await expect(textMessage).toHaveTextContaining("Attached");
+  });
+
+  it("Send files from Browse Files - Message sent with attachments is shown on remote side", async () => {
+    // Ensure that message sent with attached file is displayed on remote side
+    // With User A- Validate that message with attachment was received
+    await chatsMessagesFirstUser.switchToOtherUserWindow();
+    await chatsInputFirstUser.clickOnInputBar();
+    await chatsMessagesFirstUser.chatMessageFileEmbedRemote.waitForExist();
+
+    // Validate text from message containing attachment
+    const message = await chatsMessagesFirstUser.getLastMessageReceivedText();
+    await expect(message).toHaveTextContaining("Attached");
   });
 
   it("Chat User B - Validate compose attachments contents", async () => {
@@ -166,9 +189,9 @@ export default async function messageAttachmentsTests() {
     await chatsAttachmentFirstUser.composeAttachmentsFileEmbed.waitForExist();
 
     // Type a text message and send it
-    await chatsInputFirstUser.typeMessageOnInput("Attached");
+    await chatsInputFirstUser.typeMessageOnInput("Attached2");
     await chatsInputFirstUser.clickOnSendMessage();
-    await chatsMessagesFirstUser.waitForMessageSentToExist("Attached");
+    await chatsMessagesFirstUser.waitForMessageSentToExist("Attached2");
   });
 
   it("Chat User A - Message Sent With Attachment - Text contents", async () => {
@@ -176,7 +199,7 @@ export default async function messageAttachmentsTests() {
 
     // Validate text from message containing attachment
     const textMessage = await chatsMessagesFirstUser.getLastMessageSentText();
-    await expect(textMessage).toHaveTextContaining("Attached");
+    await expect(textMessage).toHaveTextContaining("Attached2");
   });
 
   it("Chat User A - Message Sent With Attachment - File Meta Data", async () => {
@@ -212,7 +235,7 @@ export default async function messageAttachmentsTests() {
 
     // Validate text from message containing attachment
     const message = await chatsMessagesSecondUser.getLastMessageReceivedText();
-    await expect(message).toHaveTextContaining("Attached");
+    await expect(message).toHaveTextContaining("Attached2");
   });
 
   it("Chat User B - Received Message with Attachment - File Metadata", async () => {

--- a/tests/specs/reusable-accounts/05-message-attachments.spec.ts
+++ b/tests/specs/reusable-accounts/05-message-attachments.spec.ts
@@ -22,7 +22,7 @@ export default async function messageAttachmentsTests() {
     await sendFilesSecondUser.validateNoFilesAvailableIsShown();
 
     // Click outside of the modal to close it, in this case on the send message button
-    await chatsInputSecondUser.clickOnSendMessage();
+    await sendFilesSecondUser.clickOnCloseModal();
   });
 
   it("Send files from Browse Files - Upload an image on Files to run tests", async () => {
@@ -70,8 +70,7 @@ export default async function messageAttachmentsTests() {
     await sendFilesSecondUser.validateThumbnailIsShown("logo.jpg");
   });
 
-  // Skipped since there is a bug reported for this functionality that it is not solved yet
-  xit("Send files from Browse Files - Go to files button redirects to Files", async () => {
+  it("Send files from Browse Files - Go to files button redirects to Files", async () => {
     // Click on Go To Files button and validate User is redirected to Files Screen
     await sendFilesSecondUser.clickOnGoToFiles();
     await filesScreenSecondUser.validateFilesScreenIsShown();

--- a/tests/specs/reusable-accounts/06-chat-topbar.spec.ts
+++ b/tests/specs/reusable-accounts/06-chat-topbar.spec.ts
@@ -92,7 +92,7 @@ export default async function chatTopbarTests() {
     await pinnedMessagesFirstUser.validateFirstPinnedMessageImageProfileIsShown();
     await pinnedMessagesFirstUser.validateFirstPinnedMessageTimestampIsShown();
     await pinnedMessagesFirstUser.validateFirstPinnedMessageSender("ChatUserA");
-    await pinnedMessagesFirstUser.validateFirstPinnedMessageText("Attached");
+    await pinnedMessagesFirstUser.validateFirstPinnedMessageText("Attached2");
   });
 
   it("Pinned Messages - Pinned message with attachment shows icon, extension, filename and metadata", async () => {


### PR DESCRIPTION
### What this PR does 📖

- Adding tests for sending files on chats screen by using the Browse Files section
- Adding several tests listed on the ticket below that validates all the functionalities for this windo
- Adding the corresponding screenobject file with ui locators and methods to interact with this new screen
- Improving Compose Attachments screenobject file by adding new methods to interact with UI locators and improving getters used on this file
- Updating Input Bar screenobject file to add methods to go to Browse Files section on Chat Screen

### Which issue(s) this PR fixes 🔨

- Resolve #479 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
