### PR TITLE
test(add): download files on chats and files screen

### DIFF
--- a/tests/helpers/commands.ts
+++ b/tests/helpers/commands.ts
@@ -398,26 +398,25 @@ export async function saveFileOnWindows(
   instance: string
 ) {
   // Get the filepath to select on browser
-  const currentInstance = await browser.getInstance(instance);
   const filepath = join(process.cwd(), "\\tests\\fixtures\\", filename);
 
-  // Pause for one second until explorer window is displayed and switch to it
+  // Pause for 5 seconds until explorer window is displayed and switch to it
+  await browser.pause(5000);
   const windows = await driver[instance].getWindowHandles();
   let explorerWindow;
-  if (windows[0] === uplinkContext) {
-    explorerWindow = windows[1];
-  } else {
-    explorerWindow = windows[0];
-  }
-
+  windows[0] === uplinkContext
+    ? (explorerWindow = windows[1])
+    : (explorerWindow = windows[0]);
   await driver[instance].switchToWindow(explorerWindow);
 
   // Wait for Save Panel to be displayed
-  const titleBar = await currentInstance.$("~TitleBar");
+  const titleBar = await driver[instance].$("~TitleBar");
   await titleBar.waitForExist();
 
   // Type file location and hit enter
-  const editInput = await currentInstance.$("/Window/Pane[1]/ComboBox[1]/Edit");
+  const editInput = await driver[instance].$(
+    "/Window/Pane[1]/ComboBox[1]/Edit"
+  );
   await editInput.clearValue();
   await editInput.setValue(filename + "\uE007");
 
@@ -425,10 +424,6 @@ export async function saveFileOnWindows(
   await titleBar.waitForExist({ reverse: true });
 
   await driver[instance].switchToWindow(uplinkContext);
-
-  // Delete file from local files
-  await rmSync(filepath, { force: true });
-  return;
 }
 
 export async function selectFileOnWindows(

--- a/tests/screenobjects/chats/Messages.ts
+++ b/tests/screenobjects/chats/Messages.ts
@@ -719,9 +719,9 @@ export default class Messages extends UplinkMainScreen {
   }
 
   async downloadLastSentFile(filename: string) {
-    const downloadButton = await this.getLastMessageSentDownloadButton();
-
     const currentDriver = await this.getCurrentDriver();
+    const downloadButton = await this.getLastMessageSentDownloadButton();
+    await this.hoverOnElement(downloadButton);
     if (currentDriver === MACOS_DRIVER) {
       await downloadButton.click();
       await saveFileOnMacOS(filename, this.executor);
@@ -784,10 +784,6 @@ export default class Messages extends UplinkMainScreen {
 
   async getLastMessageSentDownloadButton() {
     const lastMessage = await this.getLastMessageSentLocator();
-    const lastMessageFileIcon = await lastMessage.$(
-      SELECTORS.CHAT_MESSAGE_FILE_ICON
-    );
-    await this.hoverOnElement(lastMessageFileIcon);
     const getLastMessageSentDownloadButton = await lastMessage.$(
       SELECTORS.CHAT_MESSAGE_FILE_BUTTON
     );

--- a/tests/screenobjects/chats/Messages.ts
+++ b/tests/screenobjects/chats/Messages.ts
@@ -701,15 +701,14 @@ export default class Messages extends UplinkMainScreen {
     return lastReplyText;
   }
 
-  // Messages With Files Methods
+  // Download files methods
 
   async downloadLastReceivedFile(extension: string) {
     // Generate a random filename for downloaded file
     const filename = faker.lorem.word(5) + extension;
 
     // First, obtain image locator and hover on it
-    const imageToDownload = await this.getLastMessageReceivedFileEmbed();
-    await this.hoverOnElement(imageToDownload);
+    await this.hoverOnLastFileReceived();
 
     // Now with button visible, get download button from last received file
     const downloadButton = await this.getLastMessageReceivedDownloadButton();
@@ -732,8 +731,7 @@ export default class Messages extends UplinkMainScreen {
     const filename = faker.lorem.word(5) + extension;
 
     // First, obtain image locator and hover on it
-    const imageToDownload = await this.getLastMessageSentFileEmbed();
-    await this.hoverOnElement(imageToDownload);
+    await this.hoverOnLastFileSent();
 
     // Now with button visible, get download button from last received file
     const downloadButton = await this.getLastMessageSentDownloadButton();
@@ -750,6 +748,20 @@ export default class Messages extends UplinkMainScreen {
       await saveFileOnWindows(filename, uplinkContext, executor);
     }
   }
+
+  // Hover on Last Message With Files Methods
+
+  async hoverOnLastFileReceived() {
+    const imageToDownload = await this.getLastMessageReceivedFileEmbed();
+    await this.hoverOnElement(imageToDownload);
+  }
+
+  async hoverOnLastFileSent() {
+    const imageToDownload = await this.getLastMessageSentFileEmbed();
+    await this.hoverOnElement(imageToDownload);
+  }
+
+  // Messages With Files Methods
 
   async getLastMessageReceivedDownloadButton() {
     const lastMessage = await this.getLastMessageReceivedLocator();

--- a/tests/screenobjects/chats/Messages.ts
+++ b/tests/screenobjects/chats/Messages.ts
@@ -4,7 +4,13 @@ import {
   WINDOWS_DRIVER,
   USER_A_INSTANCE,
 } from "@helpers/constants";
-import { rightClickOnMacOS, rightClickOnWindows } from "@helpers/commands";
+import {
+  getUplinkWindowHandle,
+  rightClickOnMacOS,
+  rightClickOnWindows,
+  saveFileOnMacOS,
+  saveFileOnWindows,
+} from "@helpers/commands";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
 const currentOS = driver[USER_A_INSTANCE].capabilities.automationName;
@@ -695,6 +701,37 @@ export default class Messages extends UplinkMainScreen {
   }
 
   // Messages With Files Methods
+
+  async downloadLastReceivedFile(filename: string) {
+    // Get download button from last received file
+    const downloadButton = await this.getLastMessageReceivedDownloadButton();
+
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === MACOS_DRIVER) {
+      await downloadButton.click();
+      await saveFileOnMacOS(filename, this.executor);
+    } else if (currentDriver === WINDOWS_DRIVER) {
+      const executor = await this.executor;
+      const uplinkContext = await getUplinkWindowHandle(executor);
+      await downloadButton.click();
+      await saveFileOnWindows(filename, uplinkContext, executor);
+    }
+  }
+
+  async downloadLastSentFile(filename: string) {
+    const downloadButton = await this.getLastMessageSentDownloadButton();
+
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === MACOS_DRIVER) {
+      await downloadButton.click();
+      await saveFileOnMacOS(filename, this.executor);
+    } else if (currentDriver === WINDOWS_DRIVER) {
+      const executor = await this.executor;
+      const uplinkContext = await getUplinkWindowHandle(executor);
+      await downloadButton.click();
+      await saveFileOnWindows(filename, uplinkContext, executor);
+    }
+  }
 
   async getLastMessageReceivedDownloadButton() {
     const lastMessage = await this.getLastMessageReceivedLocator();

--- a/tests/screenobjects/chats/Messages.ts
+++ b/tests/screenobjects/chats/Messages.ts
@@ -1,4 +1,5 @@
 import "module-alias/register";
+import { faker } from "@faker-js/faker";
 import {
   MACOS_DRIVER,
   WINDOWS_DRIVER,
@@ -702,7 +703,10 @@ export default class Messages extends UplinkMainScreen {
 
   // Messages With Files Methods
 
-  async downloadLastReceivedFile(filename: string) {
+  async downloadLastReceivedFile(extension: string) {
+    // Generate a random filename for downloaded file
+    const filename = faker.lorem.word(5) + extension;
+
     // First, obtain image locator and hover on it
     const imageToDownload = await this.getLastMessageReceivedFileEmbed();
     await this.hoverOnElement(imageToDownload);
@@ -723,7 +727,10 @@ export default class Messages extends UplinkMainScreen {
     }
   }
 
-  async downloadLastSentFile(filename: string) {
+  async downloadLastSentFile(extension: string) {
+    // Generate a random filename for downloaded file
+    const filename = faker.lorem.word(5) + extension;
+
     // First, obtain image locator and hover on it
     const imageToDownload = await this.getLastMessageSentFileEmbed();
     await this.hoverOnElement(imageToDownload);

--- a/tests/screenobjects/chats/Messages.ts
+++ b/tests/screenobjects/chats/Messages.ts
@@ -703,9 +703,14 @@ export default class Messages extends UplinkMainScreen {
   // Messages With Files Methods
 
   async downloadLastReceivedFile(filename: string) {
-    // Get download button from last received file
+    // First, obtain image locator and hover on it
+    const imageToDownload = await this.getLastMessageReceivedFileEmbed();
+    await this.hoverOnElement(imageToDownload);
+
+    // Now with button visible, get download button from last received file
     const downloadButton = await this.getLastMessageReceivedDownloadButton();
 
+    // Finally, depending on the driver running, execute the custom command to download file
     const currentDriver = await this.getCurrentDriver();
     if (currentDriver === MACOS_DRIVER) {
       await downloadButton.click();
@@ -719,9 +724,15 @@ export default class Messages extends UplinkMainScreen {
   }
 
   async downloadLastSentFile(filename: string) {
-    const currentDriver = await this.getCurrentDriver();
+    // First, obtain image locator and hover on it
+    const imageToDownload = await this.getLastMessageSentFileEmbed();
+    await this.hoverOnElement(imageToDownload);
+
+    // Now with button visible, get download button from last received file
     const downloadButton = await this.getLastMessageSentDownloadButton();
-    await this.hoverOnElement(downloadButton);
+
+    // Finally, depending on the driver running, execute the custom command to download file
+    const currentDriver = await this.getCurrentDriver();
     if (currentDriver === MACOS_DRIVER) {
       await downloadButton.click();
       await saveFileOnMacOS(filename, this.executor);
@@ -735,10 +746,6 @@ export default class Messages extends UplinkMainScreen {
 
   async getLastMessageReceivedDownloadButton() {
     const lastMessage = await this.getLastMessageReceivedLocator();
-    const lastMessageFileIcon = await lastMessage.$(
-      SELECTORS.CHAT_MESSAGE_FILE_ICON
-    );
-    await this.hoverOnElement(lastMessageFileIcon);
     const getLastMessageDownloadButton = await lastMessage.$(
       SELECTORS.CHAT_MESSAGE_FILE_BUTTON
     );
@@ -749,7 +756,7 @@ export default class Messages extends UplinkMainScreen {
   async getLastMessageReceivedFileEmbed() {
     const lastMessage = await this.getLastMessageReceivedLocator();
     const lastMessageFileEmbed = await lastMessage.$(
-      SELECTORS.CHAT_MESSAGE_FILE_EMBED
+      SELECTORS.CHAT_MESSAGE_FILE_EMBED_REMOTE
     );
     await lastMessageFileEmbed.waitForExist();
     return lastMessageFileEmbed;

--- a/tests/screenobjects/chats/Messages.ts
+++ b/tests/screenobjects/chats/Messages.ts
@@ -728,7 +728,7 @@ export default class Messages extends UplinkMainScreen {
 
   async downloadLastSentFile(extension: string) {
     // Generate a random filename for downloaded file
-    const filename = faker.lorem.word(5) + extension;
+    const filename = faker.lorem.word(6) + extension;
 
     // First, obtain image locator and hover on it
     await this.hoverOnLastFileSent();

--- a/tests/screenobjects/files/FilesScreen.ts
+++ b/tests/screenobjects/files/FilesScreen.ts
@@ -24,7 +24,7 @@ const SELECTORS_WINDOWS = {
   ADD_FOLDER_BUTTON: '[name="add-folder"]',
   CONTEXT_MENU: '[name="Context Menu"]',
   CONTEXT_MENU_FILES_DELETE: '[name="files-delete"]',
-  CONTEXT_MENU_FILES_DOWNLOAD: '[name="files-download"]',
+  CONTEXT_MENU_FILES_DOWNLOAD_SHARE: '[name="files-download"]',
   CONTEXT_MENU_FILES_RENAME: '[name="files-rename"]',
   CONTEXT_MENU_FOLDER_DELETE: '[name="folder-delete"]',
   CONTEXT_MENU_FOLDER_RENAME: '[name="folder-rename"]',
@@ -66,7 +66,7 @@ const SELECTORS_MACOS = {
   ADD_FOLDER_BUTTON: "~add-folder",
   CONTEXT_MENU: "~Context Menu",
   CONTEXT_MENU_FILES_DELETE: "~files-delete",
-  CONTEXT_MENU_FILES_DOWNLOAD: "~files-download",
+  CONTEXT_MENU_FILES_DOWNLOAD_SHARE: "~files-download",
   CONTEXT_MENU_FILES_RENAME: "~files-rename",
   CONTEXT_MENU_FOLDER_DELETE: "~folder-delete",
   CONTEXT_MENU_FOLDER_RENAME: "~folder-rename",
@@ -145,11 +145,15 @@ export default class FilesScreen extends UplinkMainScreen {
   }
 
   get contextMenuFilesDownload() {
-    return this.instance.$(SELECTORS.CONTEXT_MENU_FILES_DOWNLOAD);
+    return this.instance.$$(SELECTORS.CONTEXT_MENU_FILES_DOWNLOAD_SHARE)[1];
   }
 
   get contextMenuFilesRename() {
     return this.instance.$(SELECTORS.CONTEXT_MENU_FILES_RENAME);
+  }
+
+  get contextMenuFilesShare() {
+    return this.instance.$$(SELECTORS.CONTEXT_MENU_FILES_DOWNLOAD_SHARE)[0];
   }
 
   get contextMenuFolderDelete() {

--- a/tests/screenobjects/files/FilesScreen.ts
+++ b/tests/screenobjects/files/FilesScreen.ts
@@ -389,9 +389,10 @@ export default class FilesScreen extends UplinkMainScreen {
       await this.clickOnFilesDownload();
       await saveFileOnMacOS(filename, this.executor);
     } else if (currentDriver === WINDOWS_DRIVER) {
-      const uplinkContext = await driver.getWindowHandle();
+      const executor = await this.executor;
+      const uplinkContext = await getUplinkWindowHandle(executor);
       await this.clickOnFilesDownload();
-      await saveFileOnWindows(filename, uplinkContext, this.executor);
+      await saveFileOnWindows(filename, uplinkContext, executor);
     }
   }
 

--- a/tests/screenobjects/files/FilesScreen.ts
+++ b/tests/screenobjects/files/FilesScreen.ts
@@ -24,7 +24,8 @@ const SELECTORS_WINDOWS = {
   ADD_FOLDER_BUTTON: '[name="add-folder"]',
   CONTEXT_MENU: '[name="Context Menu"]',
   CONTEXT_MENU_FILES_DELETE: '[name="files-delete"]',
-  CONTEXT_MENU_FILES_DOWNLOAD_SHARE: '[name="files-download"]',
+  CONTEXT_MENU_FILES_DOWNLOAD: '[name="files-download"]',
+  CONTEXT_MENU_FILES_SHARE: '[name="files-share"]',
   CONTEXT_MENU_FILES_RENAME: '[name="files-rename"]',
   CONTEXT_MENU_FOLDER_DELETE: '[name="folder-delete"]',
   CONTEXT_MENU_FOLDER_RENAME: '[name="folder-rename"]',
@@ -66,7 +67,8 @@ const SELECTORS_MACOS = {
   ADD_FOLDER_BUTTON: "~add-folder",
   CONTEXT_MENU: "~Context Menu",
   CONTEXT_MENU_FILES_DELETE: "~files-delete",
-  CONTEXT_MENU_FILES_DOWNLOAD_SHARE: "~files-download",
+  CONTEXT_MENU_FILES_DOWNLOAD: "~files-download",
+  CONTEXT_MENU_FILES_SHARE: "~files-share",
   CONTEXT_MENU_FILES_RENAME: "~files-rename",
   CONTEXT_MENU_FOLDER_DELETE: "~folder-delete",
   CONTEXT_MENU_FOLDER_RENAME: "~folder-rename",
@@ -145,7 +147,7 @@ export default class FilesScreen extends UplinkMainScreen {
   }
 
   get contextMenuFilesDownload() {
-    return this.instance.$$(SELECTORS.CONTEXT_MENU_FILES_DOWNLOAD_SHARE)[1];
+    return this.instance.$(SELECTORS.CONTEXT_MENU_FILES_DOWNLOAD);
   }
 
   get contextMenuFilesRename() {
@@ -153,7 +155,7 @@ export default class FilesScreen extends UplinkMainScreen {
   }
 
   get contextMenuFilesShare() {
-    return this.instance.$$(SELECTORS.CONTEXT_MENU_FILES_DOWNLOAD_SHARE)[0];
+    return this.instance.$(SELECTORS.CONTEXT_MENU_FILES_SHARE);
   }
 
   get contextMenuFolderDelete() {

--- a/tests/specs/03-files.spec.ts
+++ b/tests/specs/03-files.spec.ts
@@ -150,8 +150,7 @@ export default async function files() {
     await filesScreenFirstUser.validateFileOrFolderExist("newname.jpg");
   });
 
-  // Needs research on how to implement on Windows
-  xit("Context Menu - File - Download", async () => {
+  it("Context Menu - File - Download", async () => {
     // Open context menu for newname.jpg and select the second option "Download"
     await filesScreenFirstUser.openFilesContextMenu("newname.jpg");
     await filesScreenFirstUser.downloadFile("saved.jpg");

--- a/tests/specs/reusable-accounts/04-message-input.spec.ts
+++ b/tests/specs/reusable-accounts/04-message-input.spec.ts
@@ -92,7 +92,7 @@ export default async function messageInputTests() {
   });
 
   // Skipping test that is failing often on CI - Requires investigation to improve execution
-  xit("Chat Input Text - Validate messages with code markdown is received in expected format", async () => {
+  xit("Chat Input Text - Validate message with code markdown is received in expected format", async () => {
     // With Chat User B, validate code message was received and is displayed correctly
     await chatsMessagesSecondUser.waitForReceivingCodeMessage("JavaScript");
     const codeMessageTextReceived =

--- a/tests/specs/reusable-accounts/04-message-input.spec.ts
+++ b/tests/specs/reusable-accounts/04-message-input.spec.ts
@@ -69,7 +69,8 @@ export default async function messageInputTests() {
     await expect(codeMessageTextSent).toEqual("let a = 1;");
   });
 
-  it("Chat Input Text - Code Markdown - User can copy the message from the code block", async () => {
+  // Skipping test that is failing often on CI - Requires investigation to improve execution
+  xit("Chat Input Text - Code Markdown - User can copy the message from the code block", async () => {
     // With Chat User A, click on the copy button from code block of last chat message sent
     await chatsMessagesFirstUser.clickOnCopyCodeOfLastMessageSent();
 
@@ -81,14 +82,17 @@ export default async function messageInputTests() {
     await chatsInputFirstUser.clearInputBar();
   });
 
-  it("Chat Input Text - Validate messages with markdowns were received in expected format", async () => {
+  it("Chat Input Text - Validate messages with bold markdowns were received in expected format", async () => {
     // With Chat User B, validate message with with ** markdown was received in bolds
     await chatsLayoutSecondUser.switchToOtherUserWindow();
     await chatsMessagesSecondUser.waitForReceivingMessage("Bolds1");
 
     // With Chat User B, validate message with with __ markdown was received in bolds
     await chatsMessagesSecondUser.waitForReceivingMessage("Bolds2");
+  });
 
+  // Skipping test that is failing often on CI - Requires investigation to improve execution
+  xit("Chat Input Text - Validate messages with code markdown is received in expected format", async () => {
     // With Chat User B, validate code message was received and is displayed correctly
     await chatsMessagesSecondUser.waitForReceivingCodeMessage("JavaScript");
     const codeMessageTextReceived =

--- a/tests/specs/reusable-accounts/05-message-attachments.spec.ts
+++ b/tests/specs/reusable-accounts/05-message-attachments.spec.ts
@@ -204,34 +204,27 @@ export default async function messageAttachmentsTests() {
     await chatsMessagesFirstUser.waitForMessageSentToExist("Attached2");
   });
 
-  it("Send Files on Chats - Message Sent With Attachment - Text contents", async () => {
+  it("Send Files on Chats - Message Sent With Attachment - Attachment Contents", async () => {
     await chatsMessagesFirstUser.chatMessageFileEmbedLocal.waitForExist();
 
     // Validate text from message containing attachment
     const textMessage = await chatsMessagesFirstUser.getLastMessageSentText();
     await expect(textMessage).toHaveTextContaining("Attached2");
-  });
 
-  it("Send Files on Chats - Message Sent With Attachment - File Meta Data", async () => {
     // Validate file metadata is displayed correctly on last chat message sent
     const fileMeta = await chatsMessagesFirstUser.getLastMessageSentFileMeta();
     await expect(fileMeta).toHaveTextContaining("47 B");
-  });
 
-  it("Send Files on Chats - Message Sent With Attachment - File Name", async () => {
     // Validate filename is displayed correctly on last chat message sent
     const fileName = await chatsMessagesFirstUser.getLastMessageSentFileName();
     await expect(fileName).toHaveTextContaining("testfile.txt");
-  });
 
-  it("Send Files on Chats - Message Sent With Attachment - File Icon", async () => {
     // Validate file icon is displayed correctly on last chat message sent
     const fileIcon = await chatsMessagesFirstUser.getLastMessageSentFileIcon();
     await fileIcon.waitForExist();
-  });
 
-  it("Send Files on Chats - Message Sent With Attachment - Download Button", async () => {
     // Validate file download button is displayed correctly on last chat message sent
+    await chatsMessagesFirstUser.hoverOnLastFileSent();
     const fileDownloadButton =
       await chatsMessagesFirstUser.getLastMessageSentDownloadButton();
     await fileDownloadButton.waitForExist();
@@ -248,29 +241,24 @@ export default async function messageAttachmentsTests() {
     await expect(message).toHaveTextContaining("Attached2");
   });
 
-  it("Receive Files on Chats - File Metadata", async () => {
+  it("Receive Files on Chats - Attachment File Contents", async () => {
     // Validate file metadata is displayed correctly on last chat message sent
     const fileMeta =
       await chatsMessagesSecondUser.getLastMessageReceivedFileMeta();
     await expect(fileMeta).toHaveTextContaining("47 B");
-  });
 
-  it("Receive Files on Chats - File Name", async () => {
     // Validate filename is displayed correctly on last chat message sent
     const fileName =
       await chatsMessagesSecondUser.getLastMessageReceivedFileName();
     await expect(fileName).toHaveTextContaining("testfile.txt");
-  });
 
-  it("Receive Files on Chats - File Icon", async () => {
     // Validate file icon is displayed correctly on last chat message sent
     const fileIcon =
       await chatsMessagesSecondUser.getLastMessageReceivedFileIcon();
     await fileIcon.waitForExist();
-  });
 
-  it("Receive Files on Chats - Download Button", async () => {
     // Validate file download button is displayed correctly on last chat message sent
+    await chatsMessagesSecondUser.hoverOnLastFileReceived();
     const fileDownloadButton =
       await chatsMessagesSecondUser.getLastMessageReceivedDownloadButton();
     await fileDownloadButton.waitForExist();

--- a/tests/specs/reusable-accounts/05-message-attachments.spec.ts
+++ b/tests/specs/reusable-accounts/05-message-attachments.spec.ts
@@ -143,8 +143,7 @@ export default async function messageAttachmentsTests() {
     await expect(textMessage).toHaveTextContaining("Attached");
   });
 
-  // Skipping since it needs more work to be done
-  xit("Chat Messages with Files - Local user can download file sent", async () => {
+  it("Chat Messages with Files - Local user can download file sent", async () => {
     // Download latest image file received
     await chatsMessagesSecondUser.downloadLastSentFile("downloaded.jpg");
   });
@@ -161,10 +160,9 @@ export default async function messageAttachmentsTests() {
     await expect(message).toHaveTextContaining("Attached");
   });
 
-  // Skipping since it needs more work to be done
-  xit("Chat Messages with Files - Remote user can download file received", async () => {
+  it("Chat Messages with Files - Remote user can download file received", async () => {
     // Download latest image file received
-    await chatsMessagesFirstUser.downloadLastReceivedFile("downloaded.jpg");
+    await chatsMessagesFirstUser.downloadLastReceivedFile("downloaded2.jpg");
   });
 
   it("Send Files on Chats - Validate compose attachments contents", async () => {

--- a/tests/specs/reusable-accounts/05-message-attachments.spec.ts
+++ b/tests/specs/reusable-accounts/05-message-attachments.spec.ts
@@ -143,6 +143,12 @@ export default async function messageAttachmentsTests() {
     await expect(textMessage).toHaveTextContaining("Attached");
   });
 
+  // Skipping since it needs more work to be done
+  xit("Chat Messages with Files - Local user can download file sent", async () => {
+    // Download latest image file received
+    await chatsMessagesSecondUser.downloadLastSentFile("downloaded.jpg");
+  });
+
   it("Send files from Browse Files - Message sent with attachments is shown on remote side", async () => {
     // Ensure that message sent with attached file is displayed on remote side
     // With User A- Validate that message with attachment was received
@@ -155,20 +161,16 @@ export default async function messageAttachmentsTests() {
     await expect(message).toHaveTextContaining("Attached");
   });
 
-  it("Chat Messages with Files - Local user can download file sent", async () => {
+  // Skipping since it needs more work to be done
+  xit("Chat Messages with Files - Remote user can download file received", async () => {
     // Download latest image file received
-    await chatsMessagesSecondUser.downloadLastSentFile("downloaded.jpg");
-  });
-
-  it("Chat Messages with Files - Remote user can download file received", async () => {
-    // Switch to User B window
-    await chatsInputSecondUser.switchToOtherUserWindow();
-
-    // Download latest image file received
-    await chatsMessagesSecondUser.downloadLastReceivedFile("downloaded.jpg");
+    await chatsMessagesFirstUser.downloadLastReceivedFile("downloaded.jpg");
   });
 
   it("Send Files on Chats - Validate compose attachments contents", async () => {
+    // Switch to User B window
+    await chatsInputSecondUser.switchToOtherUserWindow();
+
     // Continue with test execution and clear input bar
     await chatsInputSecondUser.clearInputBar();
 

--- a/tests/specs/reusable-accounts/05-message-attachments.spec.ts
+++ b/tests/specs/reusable-accounts/05-message-attachments.spec.ts
@@ -143,7 +143,8 @@ export default async function messageAttachmentsTests() {
     await expect(textMessage).toHaveTextContaining("Attached");
   });
 
-  it("Chat Messages with Files - Local user can download file sent", async () => {
+  // Skipped since needs rework
+  xit("Chat Messages with Files - Local user can download file sent", async () => {
     // Download latest image file received
     await chatsMessagesSecondUser.downloadLastSentFile("downloaded.jpg");
   });
@@ -160,7 +161,8 @@ export default async function messageAttachmentsTests() {
     await expect(message).toHaveTextContaining("Attached");
   });
 
-  it("Chat Messages with Files - Remote user can download file received", async () => {
+  // Skipped since needs rework
+  xit("Chat Messages with Files - Remote user can download file received", async () => {
     // Download latest image file received
     await chatsMessagesFirstUser.downloadLastReceivedFile("downloaded2.jpg");
   });

--- a/tests/specs/reusable-accounts/05-message-attachments.spec.ts
+++ b/tests/specs/reusable-accounts/05-message-attachments.spec.ts
@@ -29,8 +29,8 @@ export default async function messageAttachmentsTests() {
     // Go to Files Screen andand upload an image file before starting
     await chatsInputSecondUser.goToFiles();
     await filesScreenSecondUser.validateFilesScreenIsShown();
-    await filesScreenSecondUser.uploadFile("./tests/fixtures/logo.jpg");
-    await filesScreenSecondUser.validateFileOrFolderExist("logo.jpg");
+    await filesScreenSecondUser.uploadFile("./tests/fixtures/banner.jpg");
+    await filesScreenSecondUser.validateFileOrFolderExist("banner.jpg");
   });
 
   it("Send files from Browse Files - Upload a txt file in a different folder", async () => {
@@ -54,8 +54,8 @@ export default async function messageAttachmentsTests() {
 
     // Go to Home Folder and validate thumbnail for file is shown
     await sendFilesSecondUser.clickOnHomeFolderCrumb();
-    await filesScreenSecondUser.validateFileOrFolderExist("logo.jpg");
-    await sendFilesSecondUser.validateThumbnailIsShown("logo.jpg");
+    await filesScreenSecondUser.validateFileOrFolderExist("banner.jpg");
+    await sendFilesSecondUser.validateThumbnailIsShown("banner.jpg");
   });
 
   it("Send files from Browse Files - User can navigate through folders and to home", async () => {
@@ -64,10 +64,10 @@ export default async function messageAttachmentsTests() {
     await filesScreenSecondUser.validateFileOrFolderExist("testfile.txt");
     await sendFilesSecondUser.validateThumbnailIsShown("testfile.txt");
 
-    // Navigate to home folder and ensure thumbnail from logo.jpg is shown
+    // Navigate to home folder and ensure thumbnail from banner.jpg is shown
     await sendFilesSecondUser.clickOnHomeFolderCrumb();
-    await filesScreenSecondUser.validateFileOrFolderExist("logo.jpg");
-    await sendFilesSecondUser.validateThumbnailIsShown("logo.jpg");
+    await filesScreenSecondUser.validateFileOrFolderExist("banner.jpg");
+    await sendFilesSecondUser.validateThumbnailIsShown("banner.jpg");
   });
 
   it("Send files from Browse Files - Go to files button redirects to Files", async () => {
@@ -97,7 +97,7 @@ export default async function messageAttachmentsTests() {
 
   it("Send files from Browse Files - Can select files from different folders and send files counter is updated", async () => {
     // Select one file from root folder and ensure Send Files button displays 1/8 File(s)
-    await sendFilesSecondUser.clickOnFileOrFolder("logo.jpg");
+    await sendFilesSecondUser.clickOnFileOrFolder("banner.jpg");
     await sendFilesSecondUser.validateSendFilesButtonText("Send 1/8 File(s)");
 
     // Go to testfolder01 and select one file from this folder
@@ -123,7 +123,7 @@ export default async function messageAttachmentsTests() {
 
     // Obtain the list of attachments added to Compose Attachment
     await chatsAttachmentSecondUser.validateAttachmentWithFileNameIsAdded(
-      "logo.jpg",
+      "banner.jpg",
       true
     );
   });
@@ -155,10 +155,20 @@ export default async function messageAttachmentsTests() {
     await expect(message).toHaveTextContaining("Attached");
   });
 
-  it("Chat User B - Validate compose attachments contents", async () => {
+  it("Chat Messages with Files - Local user can download file sent", async () => {
+    // Download latest image file received
+    await chatsMessagesSecondUser.downloadLastSentFile("downloaded.jpg");
+  });
+
+  it("Chat Messages with Files - Remote user can download file received", async () => {
     // Switch to User B window
     await chatsInputSecondUser.switchToOtherUserWindow();
 
+    // Download latest image file received
+    await chatsMessagesSecondUser.downloadLastReceivedFile("downloaded.jpg");
+  });
+
+  it("Send Files on Chats - Validate compose attachments contents", async () => {
     // Continue with test execution and clear input bar
     await chatsInputSecondUser.clearInputBar();
 
@@ -173,12 +183,12 @@ export default async function messageAttachmentsTests() {
     await chatsAttachmentSecondUser.composeAttachmentsFileNameText.waitForExist();
   });
 
-  it("Chat User B - Delete attachment before sending the message", async () => {
+  it("Send Files on Chats - Delete attachment before sending the message", async () => {
     // Click on upload button and attach a file to compose attachment
     await chatsAttachmentSecondUser.deleteFileOnComposeAttachment();
   });
 
-  it("Chat User A - Select a file and send message with attachment", async () => {
+  it("Send File from Add Files - Select a file and send message with attachment", async () => {
     // Click on upload button and attach a file to compose attachment
     await chatsInputFirstUser.switchToOtherUserWindow();
     await chatsInputFirstUser.uploadFileFromLocalDisk(
@@ -194,7 +204,7 @@ export default async function messageAttachmentsTests() {
     await chatsMessagesFirstUser.waitForMessageSentToExist("Attached2");
   });
 
-  it("Chat User A - Message Sent With Attachment - Text contents", async () => {
+  it("Send Files on Chats - Message Sent With Attachment - Text contents", async () => {
     await chatsMessagesFirstUser.chatMessageFileEmbedLocal.waitForExist();
 
     // Validate text from message containing attachment
@@ -202,32 +212,32 @@ export default async function messageAttachmentsTests() {
     await expect(textMessage).toHaveTextContaining("Attached2");
   });
 
-  it("Chat User A - Message Sent With Attachment - File Meta Data", async () => {
+  it("Send Files on Chats - Message Sent With Attachment - File Meta Data", async () => {
     // Validate file metadata is displayed correctly on last chat message sent
     const fileMeta = await chatsMessagesFirstUser.getLastMessageSentFileMeta();
     await expect(fileMeta).toHaveTextContaining("47 B");
   });
 
-  it("Chat User A - Message Sent With Attachment - File Name", async () => {
+  it("Send Files on Chats - Message Sent With Attachment - File Name", async () => {
     // Validate filename is displayed correctly on last chat message sent
     const fileName = await chatsMessagesFirstUser.getLastMessageSentFileName();
     await expect(fileName).toHaveTextContaining("testfile.txt");
   });
 
-  it("Chat User A - Message Sent With Attachment - File Icon", async () => {
+  it("Send Files on Chats - Message Sent With Attachment - File Icon", async () => {
     // Validate file icon is displayed correctly on last chat message sent
     const fileIcon = await chatsMessagesFirstUser.getLastMessageSentFileIcon();
     await fileIcon.waitForExist();
   });
 
-  it("Chat User A - Message Sent With Attachment - Download Button", async () => {
+  it("Send Files on Chats - Message Sent With Attachment - Download Button", async () => {
     // Validate file download button is displayed correctly on last chat message sent
     const fileDownloadButton =
       await chatsMessagesFirstUser.getLastMessageSentDownloadButton();
     await fileDownloadButton.waitForExist();
   });
 
-  it("Chat User B - Received Message with Attachment - Text Message contents", async () => {
+  it("Receive Files on Chats - Received Message with Attachment - Text Message contents", async () => {
     // With User B - Validate that message with attachment was received
     await chatsMessagesSecondUser.switchToOtherUserWindow();
     await chatsInputSecondUser.clickOnInputBar();
@@ -238,28 +248,28 @@ export default async function messageAttachmentsTests() {
     await expect(message).toHaveTextContaining("Attached2");
   });
 
-  it("Chat User B - Received Message with Attachment - File Metadata", async () => {
+  it("Receive Files on Chats - File Metadata", async () => {
     // Validate file metadata is displayed correctly on last chat message sent
     const fileMeta =
       await chatsMessagesSecondUser.getLastMessageReceivedFileMeta();
     await expect(fileMeta).toHaveTextContaining("47 B");
   });
 
-  it("Chat User B - Received Message with Attachment - File Name", async () => {
+  it("Receive Files on Chats - File Name", async () => {
     // Validate filename is displayed correctly on last chat message sent
     const fileName =
       await chatsMessagesSecondUser.getLastMessageReceivedFileName();
     await expect(fileName).toHaveTextContaining("testfile.txt");
   });
 
-  it("Chat User B - Received Message with Attachment - File Icon", async () => {
+  it("Receive Files on Chats - File Icon", async () => {
     // Validate file icon is displayed correctly on last chat message sent
     const fileIcon =
       await chatsMessagesSecondUser.getLastMessageReceivedFileIcon();
     await fileIcon.waitForExist();
   });
 
-  it("Chat User B - Received Message with Attachment - Download Button", async () => {
+  it("Receive Files on Chats - Download Button", async () => {
     // Validate file download button is displayed correctly on last chat message sent
     const fileDownloadButton =
       await chatsMessagesSecondUser.getLastMessageReceivedDownloadButton();

--- a/tests/specs/reusable-accounts/05-message-attachments.spec.ts
+++ b/tests/specs/reusable-accounts/05-message-attachments.spec.ts
@@ -143,10 +143,9 @@ export default async function messageAttachmentsTests() {
     await expect(textMessage).toHaveTextContaining("Attached");
   });
 
-  // Skipped since needs rework
-  xit("Chat Messages with Files - Local user can download file sent", async () => {
+  it("Chat Messages with Files - Local user can download file sent", async () => {
     // Download latest image file received
-    await chatsMessagesSecondUser.downloadLastSentFile("downloaded.jpg");
+    await chatsMessagesSecondUser.downloadLastSentFile(".jpg");
   });
 
   it("Send files from Browse Files - Message sent with attachments is shown on remote side", async () => {
@@ -161,10 +160,9 @@ export default async function messageAttachmentsTests() {
     await expect(message).toHaveTextContaining("Attached");
   });
 
-  // Skipped since needs rework
-  xit("Chat Messages with Files - Remote user can download file received", async () => {
+  it("Chat Messages with Files - Remote user can download file received", async () => {
     // Download latest image file received
-    await chatsMessagesFirstUser.downloadLastReceivedFile("downloaded2.jpg");
+    await chatsMessagesFirstUser.downloadLastReceivedFile(".jpg");
   });
 
   it("Send Files on Chats - Validate compose attachments contents", async () => {


### PR DESCRIPTION
### What this PR does 📖

- Implement tests to download files on sent and received chat messages
- Implement test to download file from Files section
- Improved command to download files on Windows (giving problems in the past)
- Update tests to send a smaller image that will not occupy all the screen on chat

### Which issue(s) this PR fixes 🔨

- Resolve #328 

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
