### PR TITLE
test(update): skip test for add and change profile pic

### DIFF
--- a/tests/specs/05-settings-profile.spec.ts
+++ b/tests/specs/05-settings-profile.spec.ts
@@ -72,8 +72,9 @@ export default async function settingsProfile() {
     await expect(statusInput).toHaveTextContaining("");
   });
 
+  // Skipping test since it needs implementation of Crop Tool recently merged
   // Needs visual validation steps to ensure that picture was actually loaded matches with expected image
-  it("Settings Profile - Add profile picture", async () => {
+  xit("Settings Profile - Add profile picture", async () => {
     await settingsProfileFirstUser.uploadProfilePicture(
       "./tests/fixtures/logo.jpg"
     );
@@ -100,8 +101,9 @@ export default async function settingsProfile() {
     );
   });
 
+  // Skipping test since it needs implementation of Crop Tool recently merged
   // Needs visual validation steps to ensure that picture was actually loaded matches with expected image
-  it("Settings Profile - Change profile picture", async () => {
+  xit("Settings Profile - Change profile picture", async () => {
     // Wait for toast notification to be closed before starting test
     await settingsProfileFirstUser.waitUntilNotificationIsClosed();
 

--- a/tests/specs/14-create-reusable-accounts.spec.ts
+++ b/tests/specs/14-create-reusable-accounts.spec.ts
@@ -21,7 +21,8 @@ export default async function createReusableAccounts() {
     await settingsProfileFirstUser.waitForIsShown(true);
   });
 
-  it("Add profile picture - Chat User A", async () => {
+  // Skipping test since it needs implementation of Crop Tool recently merged
+  xit("Add profile picture - Chat User A", async () => {
     it("Settings Profile - Add profile picture", async () => {
       await settingsProfileFirstUser.uploadProfilePicture(
         "./tests/fixtures/logo.jpg"
@@ -65,7 +66,8 @@ export default async function createReusableAccounts() {
     await settingsProfileFirstUser.waitForIsShown(true);
   });
 
-  it("Add profile picture - Chat User B", async () => {
+  // Skipping test since it needs implementation of Crop Tool recently merged
+  xit("Add profile picture - Chat User B", async () => {
     await settingsProfileFirstUser.uploadProfilePicture(
       "./tests/fixtures/second-profile.png"
     );


### PR DESCRIPTION
### What this PR does 📖

- Skipping tests for add/update profile picture until changes for crop tool are applied to tests

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
