### PR TITLE
screenobject(update): use enter key to save create folder name

### DIFF
--- a/tests/screenobjects/files/FilesScreen.ts
+++ b/tests/screenobjects/files/FilesScreen.ts
@@ -243,9 +243,7 @@ export default class FilesScreen extends UplinkMainScreen {
   }
 
   get inputFolderFileName() {
-    return this.instance
-      .$(SELECTORS.FILES_LIST)
-      .$(SELECTORS.INPUT_FOLDER_FILE_NAME);
+    return this.filesBody.$(SELECTORS.INPUT_FOLDER_FILE_NAME);
   }
 
   get showSidebar() {

--- a/tests/screenobjects/files/FilesScreen.ts
+++ b/tests/screenobjects/files/FilesScreen.ts
@@ -364,17 +364,9 @@ export default class FilesScreen extends UplinkMainScreen {
 
   async createFolder(name: string) {
     await this.clickOnCreateFolder();
-    const filesInfoCurrentSizeLabel = await this.filesInfoCurrentSizeLabel;
-    const inputFolderFileName = await this.inputFolderFileName;
-    await inputFolderFileName.waitForExist();
-    await inputFolderFileName.setValue(name);
-    // Retry typing if appium fails on type
-    const inputValue = await inputFolderFileName.getText();
-    if (inputValue !== name) {
-      await this.createFolder(name);
-    }
+    await this.typeOnFileFolderNameInput(name);
+    await this.pressEnterOnInputFileFolderName();
     // If name was typed correctly, continue with method execution
-    await filesInfoCurrentSizeLabel.click();
     const newFolder = await this.getLocatorOfFolderFile(name);
     const newFolderElement = await this.instance.$(newFolder);
     await newFolderElement.waitForExist();
@@ -382,10 +374,22 @@ export default class FilesScreen extends UplinkMainScreen {
 
   async typeOnFileFolderNameInput(name: string) {
     const inputFolderFileName = await this.inputFolderFileName;
-    await inputFolderFileName.waitForExist();
+    await inputFolderFileName.clearValue();
     await inputFolderFileName.setValue(name);
-    const filesInfoCurrentSizeLabel = await this.filesInfoCurrentSizeLabel;
-    await filesInfoCurrentSizeLabel.click();
+    const currentValue = await inputFolderFileName.getText();
+    if (currentValue !== name) {
+      await this.typeOnFileFolderNameInput(name);
+    }
+  }
+
+  async pressEnterOnInputFileFolderName() {
+    const inputFolderFileName = await this.inputFolderFileName;
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === MACOS_DRIVER) {
+      await inputFolderFileName.addValue("\n");
+    } else if (currentDriver === WINDOWS_DRIVER) {
+      await inputFolderFileName.addValue("\uE007");
+    }
   }
 
   async downloadFile(filename: string) {

--- a/tests/specs/03-files.spec.ts
+++ b/tests/specs/03-files.spec.ts
@@ -231,10 +231,12 @@ export default async function files() {
 
     // Attempt to set the new name for the file as app-macos.zip and wait for error toast notification to be closed
     await filesScreenFirstUser.typeOnFileFolderNameInput("app-macos");
+    await filesScreenFirstUser.pressEnterOnInputFileFolderName();
     await filesScreenFirstUser.waitUntilNotificationIsClosed();
 
     // Type the previous filename for app-macos (1) so it can keep the original name. Ensure that file still exists in Screen
     await filesScreenFirstUser.typeOnFileFolderNameInput("app-macos (1)");
+    await filesScreenFirstUser.pressEnterOnInputFileFolderName();
     await filesScreenFirstUser.validateFileOrFolderExist("app-macos (1).zip");
   });
 
@@ -261,10 +263,12 @@ export default async function files() {
     // Click on Create Folder and type the existing folder name "testfolder01"
     await filesScreenFirstUser.clickOnCreateFolder();
     await filesScreenFirstUser.typeOnFileFolderNameInput("testfolder01");
+    await filesScreenFirstUser.pressEnterOnInputFileFolderName();
 
     // Wait until error toast notification is closed and type a valid name for the new folder
     await filesScreenFirstUser.waitUntilNotificationIsClosed();
     await filesScreenFirstUser.typeOnFileFolderNameInput("testfolder02");
+    await filesScreenFirstUser.pressEnterOnInputFileFolderName();
 
     // Ensure that new folder was created with name "testfolder02"
     await filesScreenFirstUser.validateFileOrFolderExist("testfolder02");
@@ -277,10 +281,12 @@ export default async function files() {
 
     // Attempt to change the name of testfolder02 to existing folder name testfolder01
     await filesScreenFirstUser.typeOnFileFolderNameInput("testfolder01");
+    await filesScreenFirstUser.pressEnterOnInputFileFolderName();
 
     // Wait until error toast notification is closed and type the existing folder name for testfolder02
     await filesScreenFirstUser.waitUntilNotificationIsClosed();
     await filesScreenFirstUser.typeOnFileFolderNameInput("testfolder02");
+    await filesScreenFirstUser.pressEnterOnInputFileFolderName();
     await filesScreenFirstUser.validateFileOrFolderExist("testfolder02");
   });
 }


### PR DESCRIPTION
### What this PR does 📖

- Fixing the screenobject method for creating folder on Files Screen to use enter key to save input value. This is an attempt to fix a CI issue presented on the test Create a New folder and enter on it from MacOS CI

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
