### PR TITLE
test(add): add tests for settings messages

### DIFF
--- a/tests/screenobjects/settings/SettingsBaseScreen.ts
+++ b/tests/screenobjects/settings/SettingsBaseScreen.ts
@@ -21,6 +21,7 @@ const SELECTORS_WINDOWS = {
   EXTENSIONS_BUTTON: '[name="extensions-button"]',
   GENERAL_BUTTON: '[name="general-button"]',
   LICENSES_BUTTON: '[name="licenses-button"]',
+  MESSAGES_BUTTON: '[name="messages-button"]',
   NOTIFICATIONS_BUTTON: '[name="notifications-button"]',
   PROFILE_BUTTON: '[name="profile-button"]',
   SETTINGS_SEARCH_INPUT: '[name="settings-search-input"]',
@@ -34,6 +35,7 @@ const SELECTORS_MACOS = {
   EXTENSIONS_BUTTON: "~extensions-button",
   GENERAL_BUTTON: "~general-button",
   LICENSES_BUTTON: "~licenses-button",
+  MESSAGES_BUTTON: "~messages-button",
   NOTIFICATIONS_BUTTON: "~notifications-button",
   PROFILE_BUTTON: "~profile-button",
   SETTINGS_SEARCH_INPUT: "~settings-search-input",
@@ -92,6 +94,10 @@ export default class SettingsBaseScreen extends UplinkMainScreen {
     return this.instance.$(SELECTORS.LICENSES_BUTTON);
   }
 
+  get messagesButton() {
+    return this.instance.$(SELECTORS.MESSAGES_BUTTON);
+  }
+
   get notificationsButton() {
     return this.instance.$(SELECTORS.NOTIFICATIONS_BUTTON);
   }
@@ -141,6 +147,11 @@ export default class SettingsBaseScreen extends UplinkMainScreen {
   async goToLicensesSettings() {
     const licensesButton = await this.licensesButton;
     await licensesButton.click();
+  }
+
+  async goToMessagesSettings() {
+    const messagesButton = await this.messagesButton;
+    await messagesButton.click();
   }
 
   async goToNotificationsSettings() {

--- a/tests/screenobjects/settings/SettingsMessagesScreen.ts
+++ b/tests/screenobjects/settings/SettingsMessagesScreen.ts
@@ -1,0 +1,129 @@
+import "module-alias/register";
+import { clickOnSwitchMacOS } from "@helpers/commands";
+import {
+  MACOS_DRIVER,
+  WINDOWS_DRIVER,
+  USER_A_INSTANCE,
+} from "@helpers/constants";
+import SettingsBaseScreen from "@screenobjects/settings/SettingsBaseScreen";
+
+const currentOS = driver[USER_A_INSTANCE].capabilities.automationName;
+let SELECTORS = {};
+
+const SELECTORS_COMMON = {
+  SETTINGS_MESSAGES: "~settings-messages",
+};
+
+const SELECTORS_WINDOWS = {
+  SETTINGS_CONTROL: '[name="settings-control"]',
+  SETTINGS_CONTROL_CHECKBOX: '[name="switch-slider-value"]',
+  SETTINGS_INFO: '[name="settings-info"]',
+  SETTINGS_INFO_DESCRIPTION: "<Text>[2]",
+  SETTINGS_INFO_HEADER: "//Text[1]/Text",
+  SETTINGS_SECTION: '[name="settings-section"]',
+  SWITCH_SLIDER: '[name="Switch Slider"]',
+};
+
+const SELECTORS_MACOS = {
+  SETTINGS_CONTROL: "~settings-control",
+  SETTINGS_CONTROL_CHECKBOX: "~switch-slider-value",
+  SETTINGS_INFO: "~settings-info",
+  SETTINGS_INFO_DESCRIPTION:
+    "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText",
+  SETTINGS_INFO_HEADER: "-ios class chain:**/XCUIElementTypeStaticText[1]",
+  SETTINGS_SECTION: "~settings-section",
+  SWITCH_SLIDER: "~Switch Slider",
+};
+
+currentOS === WINDOWS_DRIVER
+  ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
+  : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
+
+export default class SettingsMessagesScreen extends SettingsBaseScreen {
+  constructor(executor: string) {
+    super(executor, SELECTORS.SETTINGS_MESSAGES);
+  }
+
+  get convertEmojiCheckbox() {
+    return this.instance
+      .$$(SELECTORS.SETTINGS_CONTROL)[0]
+      .$(SELECTORS.SWITCH_SLIDER);
+  }
+
+  get convertEmojiControllerValue() {
+    return this.instance
+      .$$(SELECTORS.SETTINGS_CONTROL)[0]
+      .$(SELECTORS.SETTINGS_CONTROL_CHECKBOX);
+  }
+
+  get convertEmojiDescription() {
+    return this.instance
+      .$$(SELECTORS.SETTINGS_SECTION)[0]
+      .$(SELECTORS.SETTINGS_INFO)
+      .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
+  }
+
+  get convertEmojiHeader() {
+    return this.instance
+      .$$(SELECTORS.SETTINGS_SECTION)[0]
+      .$(SELECTORS.SETTINGS_INFO)
+      .$(SELECTORS.SETTINGS_INFO_HEADER);
+  }
+
+  get markdownSupportCheckbox() {
+    return this.instance
+      .$$(SELECTORS.SETTINGS_CONTROL)[1]
+      .$(SELECTORS.SWITCH_SLIDER);
+  }
+
+  get markdownSupportControllerValue() {
+    return this.instance
+      .$$(SELECTORS.SETTINGS_CONTROL)[1]
+      .$(SELECTORS.SETTINGS_CONTROL_CHECKBOX);
+  }
+
+  get markdownSupportDescription() {
+    return this.instance
+      .$$(SELECTORS.SETTINGS_SECTION)[1]
+      .$(SELECTORS.SETTINGS_INFO)
+      .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
+  }
+
+  get markdownSupportHeader() {
+    return this.instance
+      .$$(SELECTORS.SETTINGS_SECTION)[1]
+      .$(SELECTORS.SETTINGS_INFO)
+      .$(SELECTORS.SETTINGS_INFO_HEADER);
+  }
+
+  get settingsMessages() {
+    return this.instance.$(SELECTORS.SETTINGS_MESSAGES);
+  }
+
+  async clickOnConvertEmoji() {
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === WINDOWS_DRIVER) {
+      const convertEmoji = await this.convertEmojiCheckbox;
+      await convertEmoji.click();
+    } else if (currentDriver === MACOS_DRIVER) {
+      const convertEmoji = await this.convertEmojiCheckbox;
+      await clickOnSwitchMacOS(convertEmoji, this.executor);
+    }
+  }
+
+  async clickOnMarkdownSupport() {
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === WINDOWS_DRIVER) {
+      const markdownSupport = await this.markdownSupportCheckbox;
+      await markdownSupport.click();
+    } else if (currentDriver === MACOS_DRIVER) {
+      const markdownSupport = await this.markdownSupportCheckbox;
+      await clickOnSwitchMacOS(markdownSupport, this.executor);
+    }
+  }
+
+  async validateSettingsMessagesIsShown() {
+    const settingsMessages = await this.settingsMessages;
+    await settingsMessages.waitForExist();
+  }
+}

--- a/tests/screenobjects/settings/SettingsNotificationsScreen.ts
+++ b/tests/screenobjects/settings/SettingsNotificationsScreen.ts
@@ -15,7 +15,6 @@ const SELECTORS_COMMON = {
 };
 
 const SELECTORS_WINDOWS = {
-  GRANT_PERMISSIONS_BUTTON: '[name="grant-permissions-button"]',
   SETTINGS_CONTROL: '[name="settings-control"]',
   SETTINGS_CONTROL_CHECKBOX: '[name="switch-slider-value"]',
   SETTINGS_INFO: '[name="settings-info"]',
@@ -26,7 +25,6 @@ const SELECTORS_WINDOWS = {
 };
 
 const SELECTORS_MACOS = {
-  GRANT_PERMISSIONS_BUTTON: "~grant-permissions-button",
   SETTINGS_CONTROL: "~settings-control",
   SETTINGS_CONTROL_CHECKBOX: "~switch-slider-value",
   SETTINGS_INFO: "~settings-info",

--- a/tests/screenobjects/settings/SettingsProfileScreen.ts
+++ b/tests/screenobjects/settings/SettingsProfileScreen.ts
@@ -25,6 +25,9 @@ const SELECTORS_COMMON = {
 
 const SELECTORS_WINDOWS = {
   ADD_PICTURE_BUTTON: '[name="add-picture-button"]',
+  CLEAR_AVATAR_BUTTON: "[name='clear-avatar']",
+  CLEAR_BANNER_BUTTON: "[name='clear-banner']",
+  CONTEXT_MENU: '[name="Context Menu"]',
   COPY_ID_BUTTON: '[name="copy-id-button"]',
   DISMISS_BUTTON: '[name="welcome-message-dismiss"]',
   INPUT_ERROR: '[name="input-error"]',
@@ -53,6 +56,9 @@ const SELECTORS_WINDOWS = {
 
 const SELECTORS_MACOS = {
   ADD_PICTURE_BUTTON: "~add-picture-button",
+  CLEAR_AVATAR_BUTTON: "clear-avatar",
+  CLEAR_BANNER_BUTTON: "clear-banner",
+  CONTEXT_MENU: "~Context Menu",
   COPY_ID_BUTTON: "~copy-id-button",
   DISMISS_BUTTON: "~welcome-message-dismiss",
   INPUT_ERROR: "~input-error",
@@ -95,6 +101,17 @@ export default class SettingsProfileScreen extends SettingsBaseScreen {
 
   get addPictureButton() {
     return this.instance.$(SELECTORS.ADD_PICTURE_BUTTON);
+  }
+
+  get clearAvatarButton() {
+    return this.instance.$(SELECTORS.CLEAR_AVATAR_BUTTON);
+  }
+  get clearBannerButton() {
+    return this.instance.$(SELECTORS.CLEAR_BANNER_BUTTON);
+  }
+
+  get contextMenuProfile() {
+    return this.profileHeader.$(SELECTORS.CONTEXT_MENU);
   }
 
   get copyIDButton() {

--- a/tests/specs/07-settings-audio.spec.ts
+++ b/tests/specs/07-settings-audio.spec.ts
@@ -1,14 +1,14 @@
 import "module-alias/register";
 import SettingsAudioScreen from "@screenobjects/settings/SettingsAudioScreen";
-import SettingsGeneralScreen from "@screenobjects/settings/SettingsGeneralScreen";
+import SettingsMessagesScreen from "@screenobjects/settings/SettingsMessagesScreen";
 import { USER_A_INSTANCE } from "@helpers/constants";
 let settingsAudioFirstUser = new SettingsAudioScreen(USER_A_INSTANCE);
-let settingsGeneralFirstUser = new SettingsGeneralScreen(USER_A_INSTANCE);
+let settingsMessagesFirstUser = new SettingsMessagesScreen(USER_A_INSTANCE);
 
 export default async function settingsAudio() {
   it("Settings Audio - Assert screen texts for input/output device and sample rate selection", async () => {
     // Go to Settings Screen and finally select the Settings Screen to validate
-    await settingsGeneralFirstUser.goToAudioSettings();
+    await settingsMessagesFirstUser.goToAudioSettings();
     await settingsAudioFirstUser.waitForIsShown(true);
 
     // Validate texts for Input Device Selection

--- a/tests/specs/15-settings-messages.spec.ts
+++ b/tests/specs/15-settings-messages.spec.ts
@@ -1,0 +1,78 @@
+import "module-alias/register";
+import SettingsGeneralScreen from "@screenobjects/settings/SettingsGeneralScreen";
+import SettingsMessagesScreen from "@screenobjects/settings/SettingsMessagesScreen";
+import { USER_A_INSTANCE } from "@helpers/constants";
+let settingsGeneralFirstUser = new SettingsGeneralScreen(USER_A_INSTANCE);
+let settingsMessagesFirstUser = new SettingsMessagesScreen(USER_A_INSTANCE);
+
+export default async function settingsMessages() {
+  it("Settings Messages - Go To Messages Settings", async () => {
+    // Go to Settings Screen and finally select the Settings Screen to validate
+    await settingsGeneralFirstUser.goToMessagesSettings();
+    await settingsMessagesFirstUser.waitForIsShown(true);
+  });
+
+  it("Settings Messages - Validate header and description texts are correct", async () => {
+    // Validate convert emoji texts
+    const convertEmojiHeader =
+      await settingsMessagesFirstUser.convertEmojiHeader;
+    const convertEmojiDescription =
+      await settingsMessagesFirstUser.convertEmojiDescription;
+    await expect(convertEmojiHeader).toHaveTextContaining("CONVERT EMOJI");
+    await expect(convertEmojiDescription).toHaveTextContaining(
+      "Convert Emoji text like ':)' into an emoji symbol like '😊'."
+    );
+
+    // Validate Markdown Support texts
+    const markdownSupportHeader =
+      await settingsMessagesFirstUser.markdownSupportHeader;
+    const markdownSupportDescription =
+      await settingsMessagesFirstUser.markdownSupportDescription;
+    await expect(markdownSupportHeader).toHaveTextContaining(
+      "MARKDOWN SUPPORT"
+    );
+    await expect(markdownSupportDescription).toHaveTextContaining(
+      "Enables the support of the Markdown markup language in messaging."
+    );
+  });
+
+  it("Settings Messages - Disable both convert emoji and markdown support toggles", async () => {
+    // Click on switch slider for Convert Emoji to disable option and then validate that toggle has now value = "0" (disabled)
+    await settingsMessagesFirstUser.clickOnConvertEmoji();
+    const convertEmojiToggle =
+      await settingsMessagesFirstUser.convertEmojiControllerValue;
+    const convertEmojiState = await settingsMessagesFirstUser.getToggleState(
+      convertEmojiToggle
+    );
+    await expect(convertEmojiState).toEqual("0");
+
+    // Click on switch slider for Markdown Support to disable option and then validate that toggle has now value = "0" (disabled)
+    await settingsMessagesFirstUser.clickOnMarkdownSupport();
+    const markdownSupportToggle =
+      await settingsMessagesFirstUser.markdownSupportControllerValue;
+    const markdownSupportState = await settingsMessagesFirstUser.getToggleState(
+      markdownSupportToggle
+    );
+    await expect(markdownSupportState).toEqual("0");
+  });
+
+  it("Settings Messages - Enable again both convert emoji and markdown support toggles", async () => {
+    // Click on switch slider for Convert Emoji to enable option and then validate that toggle has now value = "1" (enabled)
+    await settingsMessagesFirstUser.clickOnConvertEmoji();
+    const convertEmojiToggle =
+      await settingsMessagesFirstUser.convertEmojiControllerValue;
+    const convertEmojiState = await settingsMessagesFirstUser.getToggleState(
+      convertEmojiToggle
+    );
+    await expect(convertEmojiState).toEqual("1");
+
+    // Click on switch slider for Markdown Support to enable option and then validate that toggle has now value = "1" (enabled)
+    await settingsMessagesFirstUser.clickOnMarkdownSupport();
+    const markdownSupportToggle =
+      await settingsMessagesFirstUser.markdownSupportControllerValue;
+    const markdownSupportState = await settingsMessagesFirstUser.getToggleState(
+      markdownSupportToggle
+    );
+    await expect(markdownSupportState).toEqual("1");
+  });
+}

--- a/tests/suites/MainTests/01-UplinkTests.suite.ts
+++ b/tests/suites/MainTests/01-UplinkTests.suite.ts
@@ -4,6 +4,7 @@ import chats from "@specs/02-chats.spec";
 import files from "@specs/03-files.spec";
 import settingsProfile from "@specs/05-settings-profile.spec";
 import settingsGeneral from "@specs/06-settings-general.spec";
+import settingsMessages from "@specs/15-settings-messages.spec";
 import settingsAudio from "@specs/07-settings-audio.spec";
 import settingsExtensions from "@specs/08-settings-extensions.spec";
 import settingsNotifications from "@specs/09-settings-notifications.spec";
@@ -19,6 +20,7 @@ describe("MacOS Tests", function () {
   describe("Files Screen Tests", files.bind(this));
   describe("Settings Profile Tests", settingsProfile.bind(this));
   describe("Settings General Tests", settingsGeneral.bind(this));
+  describe("Settings Message Tests", settingsMessages.bind(this));
   describe("Settings Audio Tests", settingsAudio.bind(this));
   describe("Settings Extensions Tests", settingsExtensions.bind(this));
   describe("Settings Accessibility Tests", settingsAccessibility.bind(this));

--- a/tests/suites/MainTests/02-UplinkWindows.suite.ts
+++ b/tests/suites/MainTests/02-UplinkWindows.suite.ts
@@ -4,6 +4,7 @@ import chats from "@specs/02-chats.spec";
 import files from "@specs/03-files.spec";
 import settingsProfile from "@specs/05-settings-profile.spec";
 import settingsGeneral from "@specs/06-settings-general.spec";
+import settingsMessages from "@specs/15-settings-messages.spec";
 import settingsAudio from "@specs/07-settings-audio.spec";
 import settingsExtensions from "@specs/08-settings-extensions.spec";
 import settingsNotifications from "@specs/09-settings-notifications.spec";
@@ -18,6 +19,7 @@ describe("Windows Tests", function () {
   describe("Files Screen Tests", files.bind(this));
   describe("Settings Profile Tests", settingsProfile.bind(this));
   describe("Settings General Tests", settingsGeneral.bind(this));
+  describe("Settings Messages Tests", settingsMessages.bind(this));
   describe("Settings Audio Tests", settingsAudio.bind(this));
   describe("Settings Extensions Tests", settingsExtensions.bind(this));
   describe("Settings Accessibility Tests", settingsAccessibility.bind(this));


### PR DESCRIPTION
### What this PR does 📖

- Add tests for settings messages 
- Add screenobject file for new settings messages page
- Updated test suite and test specs to consider this test to be executed after Settings General and before Settings Audio tests on MacOS and Windows

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
