### PR TITLE
test(update): fix for flakky test on mac ci of files create folder

### DIFF
--- a/config/wdio.mac.ci.conf.ts
+++ b/config/wdio.mac.ci.conf.ts
@@ -102,11 +102,13 @@ export const config: WebdriverIO.Config = {
     // resolved to continue.
     onPrepare: async function() {
       const cacheFolder = homedir() + "/.uplink/.user";
+      const savedFile = join(process.cwd(), "./tests/fixtures/saved.jpg")
       const allureResultsFolder = join(process.cwd(), "./allure-results");
       const testReportFolder =  join(process.cwd(), "./test-report");
       const testResultsFolder =  join(process.cwd(), "./test-results");
       try {
         await rmSync(allureResultsFolder, { recursive: true, force: true });
+        await rmSync(savedFile, { recursive: true, force: true });
         await rmSync(testReportFolder, { recursive: true, force: true });
         await rmSync(testResultsFolder, { recursive: true, force: true });
         console.log("Deleted Artifacts Folders Successfully!");

--- a/config/wdio.mac.ci.conf.ts
+++ b/config/wdio.mac.ci.conf.ts
@@ -102,13 +102,11 @@ export const config: WebdriverIO.Config = {
     // resolved to continue.
     onPrepare: async function() {
       const cacheFolder = homedir() + "/.uplink/.user";
-      const savedFile = join(process.cwd(), "./tests/fixtures/saved.jpg")
       const allureResultsFolder = join(process.cwd(), "./allure-results");
       const testReportFolder =  join(process.cwd(), "./test-report");
       const testResultsFolder =  join(process.cwd(), "./test-results");
       try {
         await rmSync(allureResultsFolder, { recursive: true, force: true });
-        await rmSync(savedFile, { recursive: true, force: true });
         await rmSync(testReportFolder, { recursive: true, force: true });
         await rmSync(testResultsFolder, { recursive: true, force: true });
         console.log("Deleted Artifacts Folders Successfully!");

--- a/config/wdio.windows.app.conf.ts
+++ b/config/wdio.windows.app.conf.ts
@@ -106,7 +106,6 @@ export const config: WebdriverIO.Config = {
     onPrepare: async function() {
       // Declare constants for folder locations
       const cacheFolder = homedir() + "\\.uplink\\.user"
-      const savedFile = join(process.cwd(), "\\tests\\fixtures\\saved.jpg")
       const sourceReusableData = join(process.cwd(), "\\tests\\fixtures\\users\\FriendsTestUser")
       const targetReusableData = join(process.cwd(), "\\tests\\fixtures\\users\\windows\\FriendsTestUser")
       const allureResultsFolder = join(process.cwd(), "\\allure-results");
@@ -114,7 +113,6 @@ export const config: WebdriverIO.Config = {
       const testResultsFolder =  join(process.cwd(), "\\test-results");
       try {
         await rmSync(allureResultsFolder, { recursive: true, force: true });
-        await rmSync(savedFile, { recursive: true, force: true });
         await rmSync(testReportFolder, { recursive: true, force: true });
         await rmSync(testResultsFolder, { recursive: true, force: true });
         console.log("Deleted Artifacts Folders Successfully!");

--- a/config/wdio.windows.ci.conf.ts
+++ b/config/wdio.windows.ci.conf.ts
@@ -106,7 +106,6 @@ export const config: WebdriverIO.Config = {
     onPrepare: async function() {
       // Declare constants for folder locations
       const cacheFolder = homedir() + "\\.uplink\\.user"
-      const savedFile = join(process.cwd(), "\\tests\\fixtures\\saved.jpg")
       const sourceReusableData = join(process.cwd(), "\\tests\\fixtures\\users\\FriendsTestUser")
       const targetReusableData = join(process.cwd(), "\\tests\\fixtures\\users\\windows\\FriendsTestUser")
       const allureResultsFolder = join(process.cwd(), "\\allure-results");
@@ -114,7 +113,6 @@ export const config: WebdriverIO.Config = {
       const testResultsFolder =  join(process.cwd(), "\\test-results");
       try {
         await rmSync(allureResultsFolder, { recursive: true, force: true });
-        await rmSync(savedFile, { recursive: true, force: true });
         await rmSync(testReportFolder, { recursive: true, force: true });
         await rmSync(testResultsFolder, { recursive: true, force: true });
         console.log("Deleted Artifacts Folders Successfully!");

--- a/tests/screenobjects/chats/SendFiles.ts
+++ b/tests/screenobjects/chats/SendFiles.ts
@@ -27,7 +27,8 @@ const SELECTORS_WINDOWS = {
   FILES_LIST: '[name="files-list"]',
   INPUT_ERROR: '[name="input-error"]',
   INPUT_ERROR_TEXT: "<Text>",
-  INPUT_FOLDER_FILE_NAME: "//Group/Edit",
+  INPUT_FILE_NAME: '[name="file-name-input"]',
+  INPUT_FOLDER_NAME: '[name="folder-name-input"]',
   GO_TO_FILES_BUTTON: '[name="go_to_files_btn"]',
   HOME_DIR: '[name="home-dir"]',
   HOME_DIR_TEXT: '[name="Home"]',
@@ -56,7 +57,8 @@ const SELECTORS_MACOS = {
   HOME_DIR_TEXT: "~Home",
   INPUT_ERROR: "~input-error",
   INPUT_ERROR_TEXT: "-ios class chain:**/XCUIElementTypeStaticText",
-  INPUT_FOLDER_FILE_NAME: "-ios class chain:**/XCUIElementTypeTextField",
+  INPUT_FILE_NAME: '[name="file-name-input"]',
+  INPUT_FOLDER_NAME: '[name="folder-name-input"]',
   NO_FILES_AVAILABLE:
     "-ios class chain:**/XCUIElementTypeStaticText/XCUIElementTypeStaticText",
   SEND_FILES_BODY: "~send-files-body",
@@ -141,8 +143,12 @@ export default class SendFiles extends UplinkMainScreen {
     return this.inputError.$(SELECTORS.INPUT_ERROR_TEXT);
   }
 
-  get inputFolderFileName() {
-    return this.sendFilesBody.$(SELECTORS.INPUT_FOLDER_FILE_NAME);
+  get inputFileName() {
+    return this.instance.$(SELECTORS.INPUT_FILE_NAME);
+  }
+
+  get inputFolderName() {
+    return this.instance.$(SELECTORS.INPUT_FOLDER_NAME);
   }
 
   get noFilesAvailable() {
@@ -212,10 +218,16 @@ export default class SendFiles extends UplinkMainScreen {
     return result.toString();
   }
 
-  async typeOnFileFolderNameInput(name: string) {
-    const inputFolderFileName = await this.inputFolderFileName;
-    await inputFolderFileName.waitForExist();
-    await inputFolderFileName.setValue(name);
+  async typeOnFileNameInput(name: string) {
+    const inputFileName = await this.inputFileName;
+    await inputFileName.waitForExist();
+    await inputFileName.setValue(name);
+  }
+
+  async typeOnFolderNameInput(name: string) {
+    const inputFolderName = await this.inputFolderName;
+    await inputFolderName.waitForExist();
+    await inputFolderName.setValue(name);
   }
 
   async getCurrentFolder() {
@@ -258,15 +270,22 @@ export default class SendFiles extends UplinkMainScreen {
     return locator;
   }
 
-  async updateNameFileFolder(newName: string, extension: string = "") {
-    const inputFolderFileName = await this.inputFolderFileName;
-    await inputFolderFileName.waitForExist();
-    await inputFolderFileName.setValue(newName);
-    const newFileFolder = await this.getLocatorOfFolderFile(
-      newName + extension
-    );
-    const newFileFolderElement = await this.instance.$(newFileFolder);
-    await newFileFolderElement.waitForExist();
+  async updateNameFile(newName: string, extension: string = "") {
+    const inputFileName = await this.inputFileName;
+    await inputFileName.waitForExist();
+    await inputFileName.setValue(newName);
+    const newFile = await this.getLocatorOfFolderFile(newName + extension);
+    const newFileElement = await this.instance.$(newFile);
+    await newFileElement.waitForExist();
+  }
+
+  async updateNameFolder(newName: string) {
+    const inputFolderName = await this.inputFolderName;
+    await inputFolderName.waitForExist();
+    await inputFolderName.setValue(newName);
+    const newFolder = await this.getLocatorOfFolderFile(newName);
+    const newFolderElement = await this.instance.$(newFolder);
+    await newFolderElement.waitForExist();
   }
 
   async validateFileOrFolderExist(locator: string) {

--- a/tests/screenobjects/files/FilesScreen.ts
+++ b/tests/screenobjects/files/FilesScreen.ts
@@ -315,6 +315,7 @@ export default class FilesScreen extends UplinkMainScreen {
   async clickOnCreateFolder() {
     const addFolderButton = await this.addFolderButton;
     await addFolderButton.click();
+    await this.inputFolderFileName.waitForExist();
   }
 
   async clickOnFileOrFolder(locator: string) {
@@ -354,7 +355,6 @@ export default class FilesScreen extends UplinkMainScreen {
     const currentDriver = await this.getCurrentDriver();
     await this.clickOnCreateFolder();
     const inputFolderFileName = await this.inputFolderFileName;
-    await inputFolderFileName.waitForExist();
     if (currentDriver === MACOS_DRIVER) {
       await inputFolderFileName.addValue("\n");
     } else if (currentDriver === WINDOWS_DRIVER) {
@@ -364,10 +364,9 @@ export default class FilesScreen extends UplinkMainScreen {
 
   async createFolder(name: string) {
     await this.clickOnCreateFolder();
-    const filesInfoCurrentSizeLabel = await this.filesInfoCurrentSizeLabel;
     const inputFolderFileName = await this.inputFolderFileName;
-    await inputFolderFileName.waitForExist();
-    await inputFolderFileName.setValue(name);
+    const filesInfoCurrentSizeLabel = await this.filesInfoCurrentSizeLabel;
+    await this.inputFolderFileName.setValue(name);
     // Retry typing if appium fails on type
     const inputValue = await inputFolderFileName.getText();
     if (inputValue !== name) {

--- a/tests/specs/03-files.spec.ts
+++ b/tests/specs/03-files.spec.ts
@@ -126,7 +126,7 @@ export default async function files() {
     await filesScreenFirstUser.clickOnFolderRename();
 
     // Set the new name for the folder
-    await filesScreenFirstUser.updateNameFileFolder("newname");
+    await filesScreenFirstUser.updateNameFolder("newname");
     await filesScreenFirstUser.validateFileOrFolderExist("newname");
   });
 
@@ -145,14 +145,14 @@ export default async function files() {
     await filesScreenFirstUser.clickOnFilesRename();
 
     // Set the new name for the file
-    await filesScreenFirstUser.updateNameFileFolder("newname", ".jpg");
+    await filesScreenFirstUser.updateNameFile("newname", ".jpg");
     await filesScreenFirstUser.validateFileOrFolderExist("newname.jpg");
   });
 
   it("Context Menu - File - Download", async () => {
     // Open context menu for newname.jpg and select the second option "Download"
     await filesScreenFirstUser.openFilesContextMenu("newname.jpg");
-    await filesScreenFirstUser.downloadFile("saved.jpg");
+    await filesScreenFirstUser.downloadFile(".jpg");
   });
 
   it("Context Menu - File - Delete", async () => {
@@ -230,11 +230,11 @@ export default async function files() {
     await filesScreenFirstUser.clickOnFilesRename();
 
     // Attempt to set the new name for the file as app-macos.zip and wait for error toast notification to be closed
-    await filesScreenFirstUser.typeOnFileFolderNameInput("app-macos");
+    await filesScreenFirstUser.typeOnFileNameInput("app-macos");
     await filesScreenFirstUser.waitUntilNotificationIsClosed();
 
     // Type the previous filename for app-macos (1) so it can keep the original name. Ensure that file still exists in Screen
-    await filesScreenFirstUser.typeOnFileFolderNameInput("app-macos (1)");
+    await filesScreenFirstUser.typeOnFileNameInput("app-macos (1)");
     await filesScreenFirstUser.validateFileOrFolderExist("app-macos (1).zip");
   });
 
@@ -250,7 +250,7 @@ export default async function files() {
     );
 
     // Click again on Create Folder button to cancel operation
-    await filesScreenFirstUser.clickOnCreateFolder();
+    await filesScreenFirstUser.addFolderButton.click();
   });
 
   it("Files - Attempt to create a folder with existing folder name", async () => {
@@ -260,11 +260,11 @@ export default async function files() {
 
     // Click on Create Folder and type the existing folder name "testfolder01"
     await filesScreenFirstUser.clickOnCreateFolder();
-    await filesScreenFirstUser.typeOnFileFolderNameInput("testfolder01");
+    await filesScreenFirstUser.typeOnFolderNameInput("testfolder01");
 
     // Wait until error toast notification is closed and type a valid name for the new folder
     await filesScreenFirstUser.waitUntilNotificationIsClosed();
-    await filesScreenFirstUser.typeOnFileFolderNameInput("testfolder02");
+    await filesScreenFirstUser.typeOnFolderNameInput("testfolder02");
 
     // Ensure that new folder was created with name "testfolder02"
     await filesScreenFirstUser.validateFileOrFolderExist("testfolder02");
@@ -276,11 +276,11 @@ export default async function files() {
     await filesScreenFirstUser.clickOnFolderRename();
 
     // Attempt to change the name of testfolder02 to existing folder name testfolder01
-    await filesScreenFirstUser.typeOnFileFolderNameInput("testfolder01");
+    await filesScreenFirstUser.typeOnFolderNameInput("testfolder01");
 
     // Wait until error toast notification is closed and type the existing folder name for testfolder02
     await filesScreenFirstUser.waitUntilNotificationIsClosed();
-    await filesScreenFirstUser.typeOnFileFolderNameInput("testfolder02");
+    await filesScreenFirstUser.typeOnFolderNameInput("testfolder02");
     await filesScreenFirstUser.validateFileOrFolderExist("testfolder02");
   });
 }


### PR DESCRIPTION
### What this PR does 📖

- Attempt to fix the flakky test of Files - Create a Folder by updating the screenobject file of Files with a wait method for the input text on click on create folder
- Also, adding an on prepare step on mac ci config file to delete any fixtures previously saved before starting tests

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
