### PR TITLE
test(update): improve type on file folder name input and max char tests

### DIFF
--- a/tests/screenobjects/files/FilesScreen.ts
+++ b/tests/screenobjects/files/FilesScreen.ts
@@ -390,17 +390,35 @@ export default class FilesScreen extends UplinkMainScreen {
   }
 
   async typeOnFileNameInput(name: string) {
+    // Type on File Name input
     const inputFileName = await this.inputFileName;
-    await inputFileName.waitForExist();
+    await inputFileName.clearValue();
     await inputFileName.setValue(name);
+    const fileNameInputValue = await inputFileName.getText();
+
+    // Validate that input is correct before continuing
+    if (fileNameInputValue !== name) {
+      await this.typeOnFileNameInput(name);
+    }
+
+    // Click outside to save changes
     const filesInfoCurrentSizeLabel = await this.filesInfoCurrentSizeLabel;
     await filesInfoCurrentSizeLabel.click();
   }
 
   async typeOnFolderNameInput(name: string) {
+    // Type on Folder Name input
     const inputFolderName = await this.inputFolderName;
-    await inputFolderName.waitForExist();
+    await inputFolderName.clearValue();
     await inputFolderName.setValue(name);
+    const folderNameInputValue = await inputFolderName.getText();
+
+    // Validate that input is correct before continuing
+    if (folderNameInputValue !== name) {
+      await this.typeOnFolderNameInput(name);
+    }
+
+    // Click outside to save changes
     const filesInfoCurrentSizeLabel = await this.filesInfoCurrentSizeLabel;
     await filesInfoCurrentSizeLabel.click();
   }

--- a/tests/specs/04-friends.spec.ts
+++ b/tests/specs/04-friends.spec.ts
@@ -125,7 +125,7 @@ export default async function friends() {
 
     // Add two more character to add someone input
     await friendsScreenFirstUser.enterFriendDidKey(
-      "did:key:12345678901234567890123456789012345678901234567890"
+      "did:key:1234567890123456789012345678901234567890123456789"
     );
 
     const inputError = await friendsScreenFirstUser.inputErrorText;


### PR DESCRIPTION
### What this PR does 📖

- Type only one more char instead of two on friend test to validate input error message on exceeded chars on did key input field
- Improving type methods on folder and file name input methods (often failing because Appium might missed typing one char)

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
