### PR TITLE
screenobject(update): ammend my error on ui locator

### DIFF
--- a/tests/screenobjects/chats/InputBar.ts
+++ b/tests/screenobjects/chats/InputBar.ts
@@ -37,7 +37,7 @@ const SELECTORS_WINDOWS = {
 
 const SELECTORS_MACOS = {
   EDIT_MESSAGE_INPUT: "~edit-message-input",
-  EMOJI_BUTTON: "send-emoji-button",
+  EMOJI_BUTTON: "~send-emoji-button",
   INPUT_CHAR_COUNTER: "~input-char-counter",
   INPUT_CHAR_COUNTER_TEXT: "-ios class chain:**/XCUIElementTypeStaticText",
   INPUT_CHAR_MAX_TEXT:


### PR DESCRIPTION
### What this PR does 📖

- Adding Missing "~" on macos ui locator for EMOJI_BUTTON on InputBar screenobject file

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
