### PR TITLE
screenobject(update): retry typing username when appium fails

### DIFF
--- a/tests/screenobjects/settings/SettingsProfileScreen.ts
+++ b/tests/screenobjects/settings/SettingsProfileScreen.ts
@@ -279,9 +279,12 @@ export default class SettingsProfileScreen extends SettingsBaseScreen {
 
   async enterUsername(username: string) {
     const input = await this.usernameInput;
-    await input.click();
     await input.clearValue();
-    await input.addValue(username);
+    await input.setValue(username);
+    const usernameInputText = await input.getText();
+    if (usernameInputText !== username) {
+      await this.enterUsername(username);
+    }
   }
 
   async getCopiedDidFromStatusInput() {


### PR DESCRIPTION
### What this PR does 📖

- On Settings Profile screenobject, modify method to type username in order to retry setting the expected value when appium type fails

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
