### PR TITLE
chore(appium): pass config on shared file and set 3 mins

### DIFF
--- a/config/wdio.mac.multiremote.conf.ts
+++ b/config/wdio.mac.multiremote.conf.ts
@@ -27,14 +27,6 @@ export const config: WebdriverIO.Config = {
     // then the current working directory is where your `package.json` resides, so `wdio`
     // will be called from there.
     //
-    // The number of times to retry the entire specfile when it fails as a whole
-    specFileRetries: 2,
-    //
-    // Delay in seconds between the spec file retry attempts
-    specFileRetriesDelay: 30,
-    //
-    // Whether or not retried specfiles should be retried immediately or deferred to the end of the queue
-    specFileRetriesDeferred: false,
     specs: [join(process.cwd(), "./tests/suites/Chats/01-Chats.suite.ts")],
     // Patterns to exclude.
     exclude: [

--- a/config/wdio.shared.conf.ts
+++ b/config/wdio.shared.conf.ts
@@ -105,7 +105,7 @@ export const config: WebdriverIO.Config = {
          * NOTE: This has been increased for more stable Appium Native app
          * tests because they can take a bit longer.
          */
-        timeout: 120000, // 2min
+        timeout: 180000, // 3min
         bail: true,
     },
     

--- a/config/wdio.windows.app.conf.ts
+++ b/config/wdio.windows.app.conf.ts
@@ -31,8 +31,6 @@ export const config: WebdriverIO.Config = {
     exclude: [
         // 'path/to/excluded/files'
     ],
-    // The number of times to retry the entire specfile when it fails as a whole
-    specFileRetries: 2,
     //
     // ============
     // Capabilities

--- a/config/wdio.windows.ci.conf.ts
+++ b/config/wdio.windows.ci.conf.ts
@@ -31,8 +31,6 @@ export const config: WebdriverIO.Config = {
     exclude: [
         // 'path/to/excluded/files'
     ],
-    // The number of times to retry the entire specfile when it fails as a whole
-    specFileRetries: 2,
     //
     // ============
     // Capabilities

--- a/config/wdio.windows.multiremote.conf.ts
+++ b/config/wdio.windows.multiremote.conf.ts
@@ -33,19 +33,6 @@ export const config: WebdriverIO.Config = {
   exclude: [
       // 'path/to/excluded/files'
   ],
-  // The number of times to retry the entire specfile when it fails as a whole
-  specFileRetries: 2,
-  // Mocha Opts
-  mochaOpts: {
-    ui: "bdd",
-    /**
-     * NOTE: This has been increased for more stable Appium Native app
-     * tests because they can take a bit longer.
-     */
-    timeout: 180000, // 3min
-    bail: true,
-},
-
   //
   // ============
   // Capabilities

--- a/config/wdio.windows.onetime.conf.ts
+++ b/config/wdio.windows.onetime.conf.ts
@@ -1,10 +1,9 @@
 import "module-alias/register";
-import allureReporter from '@wdio/allure-reporter'
 import { config as sharedConfig } from '@config/wdio.shared.conf';
 import { homedir } from "os";
 import { join } from "path";
 const fsp = require("fs").promises;
-const { readFileSync, rmSync } = require("fs");
+const { rmSync } = require("fs");
 
 // @ts-expect-error
 export const config: WebdriverIO.Config = {
@@ -31,8 +30,6 @@ export const config: WebdriverIO.Config = {
     exclude: [
         // 'path/to/excluded/files'
     ],
-    // The number of times to retry the entire specfile when it fails as a whole
-    specFileRetries: 0,
     //
     // ============
     // Capabilities


### PR DESCRIPTION
### What this PR does 📖

- Pass mochaOpts timeout to 3 minutes since there are multiple tests taking about 1 min and 50 seconds and sometimes achieving the limit of 2 minutes
- Passing all shared configuration in shared config file and removing from specific config files

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
