### PR TITLE
chore(appium): remove artifacts after publish job

### DIFF
--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -542,9 +542,6 @@ jobs:
         uses: geekyeggo/delete-artifact@v2
         with:
           name: |
-            Uplink-windows-latest
-            uplink-windows-assets
-            Uplink-macos-latest
             test-report-macos-ci
             test-report-macos-chats
             test-report-windows-ci
@@ -567,6 +564,14 @@ jobs:
     steps:
       - name: Checkout testing directory 🔖
         uses: actions/checkout@v3
+
+      - name: Delete artifacts required on failed execution
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: |
+            Uplink-windows-latest
+            uplink-windows-assets
+            Uplink-macos-latest
 
       - name: Remove label if all test jobs succeeded
         uses: buildsville/add-remove-label@v2.0.0

--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -539,15 +539,7 @@ jobs:
             UI Automated Tests execution is complete! You can find the test results report [here](https://satellite-im.github.io/testing-uplink/${{ github.run_number }})
 
   remove-artifacts:
-    needs:
-      [
-        build-mac,
-        build-windows,
-        test-mac,
-        test-mac-chats,
-        test-windows,
-        publish-test-results,
-      ]
+    needs: publish-test-results
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -538,8 +538,30 @@ jobs:
           message: |
             UI Automated Tests execution is complete! You can find the test results report [here](https://satellite-im.github.io/testing-uplink/${{ github.run_number }})
 
-  remove-artifacts:
-    needs: publish-test-results
+      - name: Delete artifacts not required on failed execution
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: |
+            Uplink-windows-latest
+            uplink-windows-assets
+            Uplink-macos-latest
+            test-report-macos-ci
+            test-report-macos-chats
+            test-report-windows-ci
+            test-allure-mac-ci
+            test-allure-mac-chats
+            test-allure-windows-ci
+
+  remove-label:
+    needs:
+      [
+        build-mac,
+        build-windows,
+        test-mac,
+        test-mac-chats,
+        test-windows,
+        publish-test-results,
+      ]
     runs-on: ubuntu-latest
 
     steps:
@@ -553,17 +575,3 @@ jobs:
           labels: |
             Failed Automated Test
           type: remove
-
-      - name: Delete artifacts
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: |
-            Uplink-windows-latest
-            uplink-windows-assets
-            Uplink-macos-latest
-            test-report-macos-ci
-            test-report-macos-chats
-            test-report-windows-ci
-            test-allure-mac-ci
-            test-allure-mac-chats
-            test-allure-windows-ci


### PR DESCRIPTION
### What this PR does 📖

- Remove not required artifacts after publishing results when CI fails
- No need to keep builds, test reports and allure assets after results have been published
- Just keeping appium logs and appium screenshots/videos when execution is failed

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
