### PR TITLE
test(add): add tests to bypass recovery seed screens

### DIFF
--- a/tests/helpers/commands.ts
+++ b/tests/helpers/commands.ts
@@ -1,7 +1,9 @@
 require("module-alias/register");
+import CreateOrImportScreen from "@screenobjects/account-creation/CreateOrImportScreen";
 import CreatePinScreen from "@screenobjects/account-creation/CreatePinScreen";
 import CreateUserScreen from "@screenobjects/account-creation/CreateUserScreen";
 import FriendsScreen from "@screenobjects/friends/FriendsScreen";
+import SaveRecoverySeedScreen from "@screenobjects/account-creation/SaveRecoverySeedScreen";
 import WelcomeScreen from "@screenobjects/welcome-screen/WelcomeScreen";
 import { homedir } from "os";
 import { join } from "path";
@@ -17,9 +19,11 @@ const { readFileSync, rmSync, writeFileSync } = require("fs");
 const { execSync } = require("child_process");
 const fsp = require("fs").promises;
 const { clipboard, mouse, Button } = require("@nut-tree/nut-js");
+const createOrImport = new CreateOrImportScreen();
 let createPin = new CreatePinScreen();
 let createUser = new CreateUserScreen();
 let friendsScreen = new FriendsScreen();
+const saveRecoverySeed = new SaveRecoverySeedScreen();
 let welcomeScreen = new WelcomeScreen();
 
 // Users cache helper functions
@@ -105,6 +109,12 @@ export async function createNewUser(username: string) {
   await createPin.enterPin("1234");
   await createPin.createAccountButton.waitForEnabled();
   await createPin.clickOnCreateAccount();
+
+  // Bypass new Recovery Seed Screens
+  await createOrImport.waitForIsShown(true);
+  await createOrImport.clickOnCreateAccount();
+  await saveRecoverySeed.waitForIsShown(true);
+  await saveRecoverySeed.clickOnISavedItButton();
 
   // Enter Username and click on Create Account
   await createUser.enterUsername(username);

--- a/tests/screenobjects/account-creation/CreateOrImportScreen.ts
+++ b/tests/screenobjects/account-creation/CreateOrImportScreen.ts
@@ -37,11 +37,11 @@ export default class CreateOrImportScreen extends UplinkMainScreen {
   }
 
   get createNewAccountButton() {
-    return $(SELECTORS.CREATE_NEW_ACCOUNT_BUTTON);
+    return this.recoveryLayout.$(SELECTORS.CREATE_NEW_ACCOUNT_BUTTON);
   }
 
   get createOrRecoverLabel() {
-    return $(SELECTORS.CREATE_OR_RECOVER_LABEL);
+    return this.recoveryLayout.$(SELECTORS.CREATE_OR_RECOVER_LABEL);
   }
 
   get createOrRecoverLabelText() {
@@ -49,7 +49,7 @@ export default class CreateOrImportScreen extends UplinkMainScreen {
   }
 
   get importAccountButton() {
-    return $(SELECTORS.IMPORT_ACCOUNT_BUTTON);
+    return this.recoveryLayout.$(SELECTORS.IMPORT_ACCOUNT_BUTTON);
   }
 
   get recoveryLayout() {
@@ -57,7 +57,7 @@ export default class CreateOrImportScreen extends UplinkMainScreen {
   }
 
   get recoveryParagraph() {
-    return $(SELECTORS.RECOVERY_PARAGRAPH);
+    return this.recoveryLayout.$(SELECTORS.RECOVERY_PARAGRAPH);
   }
 
   async clickOnCreateAccount() {

--- a/tests/screenobjects/account-creation/CreateOrImportScreen.ts
+++ b/tests/screenobjects/account-creation/CreateOrImportScreen.ts
@@ -1,0 +1,72 @@
+require("module-alias/register");
+import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
+import { WINDOWS_DRIVER } from "@helpers/constants";
+
+const currentOS = driver.capabilities.automationName;
+let SELECTORS = {};
+
+const SELECTORS_COMMON = {};
+
+const SELECTORS_WINDOWS = {
+  CREATE_NEW_ACCOUNT_BUTTON: "<Button>[1]",
+  CREATE_OR_RECOVER_LABEL: '[name="create-or-recover"]',
+  CREATE_OR_RECOVER_LABEL_TEXT: "<Text>",
+  IMPORT_ACCOUNT_BUTTON: "<Button>[2]",
+  RECOVERY_LAYOUT: '[name="create-or-recover-layout"]',
+  RECOVERY_PARAGRAPH:
+    '//Group/Text[contains(@Name, "going to create an account")]',
+};
+
+const SELECTORS_MACOS = {
+  CREATE_NEW_ACCOUNT_BUTTON: "-ios class chain:**/XCUIElementTypeButton[1]",
+  CREATE_OR_RECOVER_LABEL: "~create-or-recover",
+  CREATE_OR_RECOVER_LABEL_TEXT: "-ios class chain:**/XCUIElementTypeStaticText",
+  IMPORT_ACCOUNT_BUTTON: "-ios class chain:**/XCUIElementTypeButton[2]",
+  RECOVERY_LAYOUT: "~create-or-recover-layout",
+  RECOVERY_PARAGRAPH:
+    '-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText[`value CONTAINS[cd] "going to create an account"`]',
+};
+
+currentOS === WINDOWS_DRIVER
+  ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
+  : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
+
+export default class CreateOrImportScreen extends UplinkMainScreen {
+  constructor() {
+    super(SELECTORS.RECOVERY_LAYOUT);
+  }
+
+  get createNewAccountButton() {
+    return $(SELECTORS.CREATE_NEW_ACCOUNT_BUTTON);
+  }
+
+  get createOrRecoverLabel() {
+    return $(SELECTORS.CREATE_OR_RECOVER_LABEL);
+  }
+
+  get createOrRecoverLabelText() {
+    return this.createOrRecoverLabel.$(SELECTORS.CREATE_OR_RECOVER_LABEL_TEXT);
+  }
+
+  get importAccountButton() {
+    return $(SELECTORS.IMPORT_ACCOUNT_BUTTON);
+  }
+
+  get recoveryLayout() {
+    return $(SELECTORS.RECOVERY_LAYOUT);
+  }
+
+  get recoveryParagraph() {
+    return $(SELECTORS.RECOVERY_PARAGRAPH);
+  }
+
+  async clickOnCreateAccount() {
+    const createAccountButton = await this.createNewAccountButton;
+    await createAccountButton.click();
+  }
+
+  async clickOnImportAccount() {
+    const importAccountButton = await this.importAccountButton;
+    await importAccountButton.click();
+  }
+}

--- a/tests/screenobjects/account-creation/CreateUserScreen.ts
+++ b/tests/screenobjects/account-creation/CreateUserScreen.ts
@@ -12,12 +12,18 @@ const SELECTORS_COMMON = {
 
 const SELECTORS_WINDOWS = {
   CREATE_ACCOUNT_BUTTON: '[name="create-account-button"]',
+  CREATE_USER_HELPER_TEXT: '//Group/Text[contains(@Name, "Time to pick")]',
+  CREATE_USER_LABEL_TEXT: "//Text/Text",
   INPUT_ERROR: '[name="input-error"]',
   INPUT_ERROR_TEXT: "<Text>",
 };
 
 const SELECTORS_MACOS = {
   CREATE_ACCOUNT_BUTTON: "~create-account-button",
+  CREATE_USER_HELPER_TEXT:
+    '-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText[`value CONTAINS[cd] "Time to pick"`]',
+  CREATE_USER_LABEL_TEXT:
+    "-ios class chain:**/XCUIElementTypeStaticText/XCUIElementTypeStaticText",
   INPUT_ERROR: "~input-error",
   INPUT_ERROR_TEXT: "-ios class chain:**/XCUIElementTypeStaticText",
 };

--- a/tests/screenobjects/account-creation/EnterRecoverySeedScreen.ts
+++ b/tests/screenobjects/account-creation/EnterRecoverySeedScreen.ts
@@ -43,23 +43,23 @@ export default class EnterRecoverySeedScreen extends UplinkMainScreen {
   }
 
   get goBackButton() {
-    return $(SELECTORS.GO_BACK_BUTTON);
+    return this.enterSeedsWordLayout.$(SELECTORS.GO_BACK_BUTTON);
   }
 
   get recoverAccountButton() {
-    return $(SELECTORS.RECOVER_ACCOUNT_BUTTON);
+    return this.enterSeedsWordLayout.$(SELECTORS.RECOVER_ACCOUNT_BUTTON);
   }
 
   get recoverySeedHelperText() {
-    return $(SELECTORS.RECOVERY_SEED_HELPER_TEXT);
+    return this.enterSeedsWordLayout.$(SELECTORS.RECOVERY_SEED_HELPER_TEXT);
   }
 
   get recoverySeedInput() {
-    return $(SELECTORS.RECOVERY_SEED_INPUT);
+    return this.enterSeedsWordLayout.$(SELECTORS.RECOVERY_SEED_INPUT);
   }
 
   get recoverySeedTitle() {
-    return $(SELECTORS.RECOVERY_SEED_TITLE);
+    return this.enterSeedsWordLayout.$(SELECTORS.RECOVERY_SEED_TITLE);
   }
 
   get recoverySeedTitleText() {

--- a/tests/screenobjects/account-creation/EnterRecoverySeedScreen.ts
+++ b/tests/screenobjects/account-creation/EnterRecoverySeedScreen.ts
@@ -1,0 +1,83 @@
+require("module-alias/register");
+import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
+import { WINDOWS_DRIVER } from "@helpers/constants";
+
+const currentOS = driver.capabilities.automationName;
+let SELECTORS = {};
+
+const SELECTORS_COMMON = {};
+
+const SELECTORS_WINDOWS = {
+  ENTER_SEEDS_WORD_LAYOUT: '[name="enter-seed-words-layout"]',
+  GO_BACK_BUTTON: '[name="back-button"]',
+  RECOVER_ACCOUNT_BUTTON: "<Button>[2]",
+  RECOVERY_SEED_HELPER_TEXT:
+    '//Group/Text[contains(@Name, "Type your recovery seed")]',
+  RECOVERY_SEED_INPUT: "<Edit>",
+  RECOVERY_SEED_TITLE: '[name="enter-seed-words"]',
+  RECOVERY_SEED_TITLE_TEXT: "<Text>",
+};
+
+const SELECTORS_MACOS = {
+  ENTER_SEEDS_WORD_LAYOUT: "~enter-seed-words-layout",
+  GO_BACK_BUTTON: "~back-button",
+  RECOVER_ACCOUNT_BUTTON: "-ios class chain:**/XCUIElementTypeButton[2]",
+  RECOVERY_SEED_HELPER_TEXT:
+    '-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText[`value CONTAINS[cd] "Type your recovery seed"`]',
+  RECOVERY_SEED_INPUT: "-ios class chain:**/XCUIElementTypeTextField",
+  RECOVERY_SEED_TITLE: "~enter-seed-words",
+  RECOVERY_SEED_TITLE_TEXT: "<Text>",
+};
+
+currentOS === WINDOWS_DRIVER
+  ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
+  : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
+
+export default class EnterRecoverySeedScreen extends UplinkMainScreen {
+  constructor() {
+    super(SELECTORS.ENTER_SEEDS_WORD_LAYOUT);
+  }
+
+  get enterSeedsWordLayout() {
+    return $(SELECTORS.ENTER_SEEDS_WORD_LAYOUT);
+  }
+
+  get goBackButton() {
+    return $(SELECTORS.GO_BACK_BUTTON);
+  }
+
+  get recoverAccountButton() {
+    return $(SELECTORS.RECOVER_ACCOUNT_BUTTON);
+  }
+
+  get recoverySeedHelperText() {
+    return $(SELECTORS.RECOVERY_SEED_HELPER_TEXT);
+  }
+
+  get recoverySeedInput() {
+    return $(SELECTORS.RECOVERY_SEED_INPUT);
+  }
+
+  get recoverySeedTitle() {
+    return $(SELECTORS.RECOVERY_SEED_TITLE);
+  }
+
+  get recoverySeedTitleText() {
+    return this.recoverySeedTitle.$(SELECTORS.RECOVERY_SEED_TITLE_TEXT);
+  }
+
+  async clickOnBackButton() {
+    const goBackButton = await this.goBackButton;
+    await goBackButton.click();
+  }
+
+  async clickOnRecoverAccountButton() {
+    const recoverAccountButton = await this.recoverAccountButton;
+    await recoverAccountButton.click();
+  }
+
+  async typeOnRecoverySeedInput(seed: string) {
+    const recoverySeedInput = await this.recoverySeedInput;
+    await recoverySeedInput.setValue(seed);
+  }
+}

--- a/tests/screenobjects/account-creation/SaveRecoverySeedScreen.ts
+++ b/tests/screenobjects/account-creation/SaveRecoverySeedScreen.ts
@@ -1,0 +1,72 @@
+require("module-alias/register");
+import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
+import { WINDOWS_DRIVER } from "@helpers/constants";
+
+const currentOS = driver.capabilities.automationName;
+let SELECTORS = {};
+
+const SELECTORS_COMMON = {};
+
+const SELECTORS_WINDOWS = {
+  COPY_SEED_HELPER_TEXT:
+    '//Group/Text[contains(@Name, "Write these words down")]',
+  COPY_SEED_WORDS_LABEL: '[name="copy-seed-words"]',
+  COPY_SEED_WORDS_LABEL_TEXT: "<Text>>",
+  COPY_SEED_WORDS_LAYOUT: '[name="copy-seed-words-layout"]',
+  GO_BACK_BUTTON: '[name="back-button"]',
+  I_SAVED_IT_BUTTON: "<Button>[2]",
+};
+
+const SELECTORS_MACOS = {
+  COPY_SEED_HELPER_TEXT:
+    '-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText[`value CONTAINS[cd] "Write these words down"`]',
+  COPY_SEED_WORDS_LABEL: "~copy-seed-words",
+  COPY_SEED_WORDS_LABEL_TEXT: "-ios class chain:**/XCUIElementTypeStaticText",
+  COPY_SEED_WORDS_LAYOUT: "~copy-seed-words-layout",
+  GO_BACK_BUTTON: "~back-button",
+  I_SAVED_IT_BUTTON: "-ios class chain:**/XCUIElementTypeButton[2]",
+};
+
+currentOS === WINDOWS_DRIVER
+  ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
+  : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
+
+export default class SaveRecoverySeedScreen extends UplinkMainScreen {
+  constructor() {
+    super(SELECTORS.COPY_SEED_WORDS_LAYOUT);
+  }
+
+  get copySeedHelperText() {
+    return $(SELECTORS.COPY_SEED_HELPER_TEXT);
+  }
+
+  get copySeedWordsLabel() {
+    return $(SELECTORS.COPY_SEED_WORDS_LABEL);
+  }
+
+  get copySeedWordsLabelText() {
+    return this.copySeedWordsLabel.$(SELECTORS.COPY_SEED_WORDS_LABEL_TEXT);
+  }
+
+  get copySeedsWordsLayout() {
+    return $(SELECTORS.COPY_SEED_WORDS_LAYOUT);
+  }
+
+  get goBackButton() {
+    return $(SELECTORS.GO_BACK_BUTTON);
+  }
+
+  get iSavedItButton() {
+    return $(SELECTORS.I_SAVED_IT_BUTTON);
+  }
+
+  async clickOnGoBackButton() {
+    const goBackButton = await this.goBackButton;
+    await goBackButton.click();
+  }
+
+  async clickOnISavedItButton() {
+    const iSavedItButton = await this.iSavedItButton;
+    await iSavedItButton.click();
+  }
+}

--- a/tests/screenobjects/account-creation/SaveRecoverySeedScreen.ts
+++ b/tests/screenobjects/account-creation/SaveRecoverySeedScreen.ts
@@ -37,11 +37,11 @@ export default class SaveRecoverySeedScreen extends UplinkMainScreen {
   }
 
   get copySeedHelperText() {
-    return $(SELECTORS.COPY_SEED_HELPER_TEXT);
+    return this.copySeedsWordsLayout.$(SELECTORS.COPY_SEED_HELPER_TEXT);
   }
 
   get copySeedWordsLabel() {
-    return $(SELECTORS.COPY_SEED_WORDS_LABEL);
+    return this.copySeedsWordsLayout.$(SELECTORS.COPY_SEED_WORDS_LABEL);
   }
 
   get copySeedWordsLabelText() {
@@ -53,11 +53,11 @@ export default class SaveRecoverySeedScreen extends UplinkMainScreen {
   }
 
   get goBackButton() {
-    return $(SELECTORS.GO_BACK_BUTTON);
+    return this.copySeedsWordsLayout.$(SELECTORS.GO_BACK_BUTTON);
   }
 
   get iSavedItButton() {
-    return $(SELECTORS.I_SAVED_IT_BUTTON);
+    return this.copySeedsWordsLayout.$(SELECTORS.I_SAVED_IT_BUTTON);
   }
 
   async clickOnGoBackButton() {

--- a/tests/specs/01-create-account.spec.ts
+++ b/tests/specs/01-create-account.spec.ts
@@ -1,10 +1,14 @@
 require("module-alias/register");
 import { maximizeWindow } from "@helpers/commands";
+import CreateOrImportScreen from "@screenobjects/account-creation/CreateOrImportScreen";
 import CreatePinScreen from "@screenobjects/account-creation/CreatePinScreen";
 import CreateUserScreen from "@screenobjects/account-creation/CreateUserScreen";
+import SaveRecoverySeedScreen from "@screenobjects/account-creation/SaveRecoverySeedScreen";
 import WelcomeScreen from "@screenobjects/welcome-screen/WelcomeScreen";
+const createOrImport = new CreateOrImportScreen();
 const createPin = new CreatePinScreen();
 const createUser = new CreateUserScreen();
+const saveRecoverySeed = new SaveRecoverySeedScreen();
 const welcomeScreen = new WelcomeScreen();
 
 export default async function createAccountTests() {
@@ -109,6 +113,13 @@ export default async function createAccountTests() {
     const statusOfButton = await createPin.getStatusOfCreateAccountButton();
     await expect(statusOfButton).toEqual("true");
     await createPin.clickOnCreateAccount();
+  });
+
+  it("Create or Import Account Screen - Click on Create New Account and save receovery seed", async () => {
+    await createOrImport.waitForIsShown(true);
+    await createOrImport.clickOnCreateAccount();
+    await saveRecoverySeed.waitForIsShown(true);
+    await saveRecoverySeed.clickOnISavedItButton();
     await createUser.waitForIsShown(true);
   });
 


### PR DESCRIPTION
### What this PR does 📖

- Add new screenobject files for new screens related to "Copy Seed Screen", "Enter Seed Screen" and "Create or Import Account" screens. These are still not complete and require some aria labels to be added to improve UI locators
- Added test steps to bypass these screens for now

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
