### PR TITLE
chore(appium): get current driver from env variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
     "mac.app": "DRIVER=mac2 npx wdio config/wdio.mac.app.conf.ts",
     "mac.ci": "DRIVER=mac2 npx wdio config/wdio.mac.ci.conf.ts",
     "mac.multiremote": "DRIVER=mac2 npx wdio config/wdio.mac.multiremote.conf.ts",
-    "windows.app": "$env:DRIVER=windows -and npx wdio config/wdio.windows.app.conf.ts",
-    "windows.ci": "$env:DRIVER=windows -and npx wdio config/wdio.windows.ci.conf.ts",
-    "windows.onetimescript": "$env:DRIVER=windows -and npx wdio config/wdio.windows.onetime.conf.ts",
+    "windows.app": "powershell -ExecutionPolicy Bypass -File .\\scripts\\windows_app.ps1",
+    "windows.ci": "powershell -File .\\scripts\\windows_ci.ps1",
     "lint": "eslint config tests"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "1.0.0",
   "description": "An automation testing framework built with WebdriverIO and Appium to test Uplink Desktop app",
   "scripts": {
-    "mac.app": "wdio config/wdio.mac.app.conf.ts",
-    "mac.ci": "wdio config/wdio.mac.ci.conf.ts",
-    "mac.multiremote": "wdio config/wdio.mac.multiremote.conf.ts",
-    "windows.app": "wdio config/wdio.windows.app.conf.ts",
-    "windows.ci": "wdio config/wdio.windows.ci.conf.ts",
-    "windows.onetimescript": "wdio config/wdio.windows.onetime.conf.ts",
+    "mac.app": "DRIVER=mac2 wdio config/wdio.mac.app.conf.ts",
+    "mac.ci": "DRIVER=mac2 wdio config/wdio.mac.ci.conf.ts",
+    "mac.multiremote": "DRIVER=mac2 wdio config/wdio.mac.multiremote.conf.ts",
+    "windows.app": "DRIVER=windows wdio config/wdio.windows.app.conf.ts",
+    "windows.ci": "DRIVER=windows wdio config/wdio.windows.ci.conf.ts",
+    "windows.onetimescript": "DRIVER=windows wdio config/wdio.windows.onetime.conf.ts",
     "lint": "eslint config tests"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "1.0.0",
   "description": "An automation testing framework built with WebdriverIO and Appium to test Uplink Desktop app",
   "scripts": {
-    "mac.app": "DRIVER=mac2 wdio config/wdio.mac.app.conf.ts",
-    "mac.ci": "DRIVER=mac2 wdio config/wdio.mac.ci.conf.ts",
-    "mac.multiremote": "DRIVER=mac2 wdio config/wdio.mac.multiremote.conf.ts",
-    "windows.app": "DRIVER=windows wdio config/wdio.windows.app.conf.ts",
-    "windows.ci": "DRIVER=windows wdio config/wdio.windows.ci.conf.ts",
-    "windows.onetimescript": "DRIVER=windows wdio config/wdio.windows.onetime.conf.ts",
+    "mac.app": "DRIVER=mac2 npx wdio config/wdio.mac.app.conf.ts",
+    "mac.ci": "DRIVER=mac2 npx wdio config/wdio.mac.ci.conf.ts",
+    "mac.multiremote": "DRIVER=mac2 npx wdio config/wdio.mac.multiremote.conf.ts",
+    "windows.app": "DRIVER=windows npx wdio config/wdio.windows.app.conf.ts",
+    "windows.ci": "DRIVER=windows npx wdio config/wdio.windows.ci.conf.ts",
+    "windows.onetimescript": "DRIVER=windows npx wdio config/wdio.windows.onetime.conf.ts",
     "lint": "eslint config tests"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "mac.app": "DRIVER=mac2 npx wdio config/wdio.mac.app.conf.ts",
     "mac.ci": "DRIVER=mac2 npx wdio config/wdio.mac.ci.conf.ts",
     "mac.multiremote": "DRIVER=mac2 npx wdio config/wdio.mac.multiremote.conf.ts",
-    "windows.app": "DRIVER=windows npx wdio config/wdio.windows.app.conf.ts",
-    "windows.ci": "DRIVER=windows npx wdio config/wdio.windows.ci.conf.ts",
-    "windows.onetimescript": "DRIVER=windows npx wdio config/wdio.windows.onetime.conf.ts",
+    "windows.app": "$env:DRIVER=windows -and npx wdio config/wdio.windows.app.conf.ts",
+    "windows.ci": "$env:DRIVER=windows -and npx wdio config/wdio.windows.ci.conf.ts",
+    "windows.onetimescript": "$env:DRIVER=windows -and npx wdio config/wdio.windows.onetime.conf.ts",
     "lint": "eslint config tests"
   },
   "repository": {

--- a/scripts/windows_app.ps1
+++ b/scripts/windows_app.ps1
@@ -1,0 +1,2 @@
+$env:DRIVER="windows"
+npx wdio config/wdio.windows.app.conf.ts

--- a/scripts/windows_ci.ps1
+++ b/scripts/windows_ci.ps1
@@ -1,0 +1,2 @@
+$env:DRIVER="windows"
+npx wdio config/wdio.windows.ci.conf.ts

--- a/tests/helpers/commands.ts
+++ b/tests/helpers/commands.ts
@@ -42,7 +42,7 @@ export async function deleteCache() {
 
 export async function grabCacheFolder(username: string) {
   const source = homedir() + "/.uplink";
-  const currentDriver = await driver.capabilities.automationName;
+  const currentDriver = process.env.DRIVER;
   const target = "./tests/fixtures/users/" + currentDriver + "/" + username;
   await fsp.mkdir(target, { recursive: true });
   try {
@@ -57,7 +57,7 @@ export async function grabCacheFolder(username: string) {
 
 export async function loadTestUserData(user: string) {
   // Move files
-  const currentDriver = await driver.capabilities.automationName;
+  const currentDriver = process.env.DRIVER;
   let source, target;
   source = "./tests/fixtures/users/" + currentDriver + "/" + user;
   target = homedir() + "/.uplink";
@@ -76,7 +76,7 @@ export async function loadTestUserData(user: string) {
 
 export async function getUserKey(username: string) {
   // Read user data and store variable with DID Key from JSON file
-  const currentDriver = await driver.capabilities.automationName;
+  const currentDriver = process.env.DRIVER;
   const source =
     "./tests/fixtures/users/" + currentDriver + "/" + username + ".json";
   const jsonFile = await readFileSync(source);
@@ -87,7 +87,7 @@ export async function getUserKey(username: string) {
 
 export async function saveTestKeys(username: string, didkey: string) {
   // Save JSON file with keys
-  const currentDriver = await driver.capabilities.automationName;
+  const currentDriver = process.env.DRIVER;
   const target = "./tests/fixtures/users/" + currentDriver;
   const filepath = target + "/" + username + ".json";
   await fsp.mkdir(target, { recursive: true });
@@ -157,14 +157,13 @@ export async function launchApplication(
   bundle: string = MACOS_BUNDLE_ID,
   appLocation: string = WINDOWS_APP,
 ) {
-  const currentOS = await driver.capabilities.automationName;
-  if (currentOS === WINDOWS_DRIVER) {
+  if (process.env.DRIVER === WINDOWS_DRIVER) {
     await driver.executeScript("windows: launchApp", [
       {
         app: join(process.cwd(), appLocation),
       },
     ]);
-  } else if (currentOS === MACOS_DRIVER) {
+  } else if (process.env.DRIVER === MACOS_DRIVER) {
     await driver.executeScript("macos: launchApp", [
       {
         bundleId: bundle,
@@ -201,14 +200,13 @@ export async function launchSecondApplication() {
 }
 
 export async function activateFirstApplication() {
-  const currentOS = await driver.capabilities.automationName;
-  if (currentOS === WINDOWS_DRIVER) {
+  if (process.env.DRIVER === WINDOWS_DRIVER) {
     await driver.executeScript("windows: activateApp", [
       {
         app: join(process.cwd(), WINDOWS_APP),
       },
     ]);
-  } else if (currentOS === MACOS_DRIVER) {
+  } else if (process.env.DRIVER === MACOS_DRIVER) {
     await driver.executeScript("macos: activateApp", [
       {
         bundleId: MACOS_USER_A_BUNDLE_ID,
@@ -218,14 +216,13 @@ export async function activateFirstApplication() {
 }
 
 export async function activateSecondApplication() {
-  const currentOS = await driver.capabilities.automationName;
-  if (currentOS === WINDOWS_DRIVER) {
+  if (process.env.DRIVER === WINDOWS_DRIVER) {
     await driver.executeScript("windows: activateApp", [
       {
         app: join(process.cwd(), WINDOWS_APP),
       },
     ]);
-  } else if (currentOS === MACOS_DRIVER) {
+  } else if (process.env.DRIVER === MACOS_DRIVER) {
     await driver.executeScript("macos: activateApp", [
       {
         bundleId: MACOS_USER_B_BUNDLE_ID,
@@ -235,14 +232,13 @@ export async function activateSecondApplication() {
 }
 
 export async function closeApplication() {
-  const currentOS = await driver.capabilities.automationName;
-  if (currentOS === WINDOWS_DRIVER) {
+  if (process.env.DRIVER === WINDOWS_DRIVER) {
     await driver.executeScript("windows: closeApp", [
       {
         app: join(process.cwd(), WINDOWS_APP),
       },
     ]);
-  } else if (currentOS === MACOS_DRIVER) {
+  } else if (process.env.DRIVER === MACOS_DRIVER) {
     await driver.executeScript("macos: terminateApp", [
       {
         bundleId: MACOS_BUNDLE_ID,
@@ -268,11 +264,10 @@ export async function closeSecondApplication() {
 }
 
 export async function maximizeWindow() {
-  const currentOS = await driver.capabilities.automationName;
-  if (currentOS === WINDOWS_DRIVER) {
+  if (process.env.DRIVER === WINDOWS_DRIVER) {
     const button = await $('[name="square-button"]');
     await button.click();
-  } else if (currentOS === MACOS_DRIVER) {
+  } else if (process.env.DRIVER === MACOS_DRIVER) {
     const button = await $("~_XCUI:FullScreenWindow");
     await button.click();
   }

--- a/tests/screenobjects/AppScreen.ts
+++ b/tests/screenobjects/AppScreen.ts
@@ -7,7 +7,7 @@ export default class AppScreen {
   }
 
   async getCurrentDriver() {
-    const currentDriver = await driver.capabilities.automationName;
+    const currentDriver = process.env.DRIVER;
     return currentDriver;
   }
 

--- a/tests/screenobjects/UplinkMainScreen.ts
+++ b/tests/screenobjects/UplinkMainScreen.ts
@@ -3,7 +3,6 @@ import AppScreen from "@screenobjects/AppScreen";
 import { hoverOnMacOS, hoverOnWindows } from "@helpers/commands";
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -66,7 +65,7 @@ const SELECTORS_MACOS = {
   WINDOW: "-ios class chain:**/XCUIElementTypeWindow",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/account-creation/CreateOrImportScreen.ts
+++ b/tests/screenobjects/account-creation/CreateOrImportScreen.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 import { WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -27,7 +26,7 @@ const SELECTORS_MACOS = {
     '-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText[`value CONTAINS[cd] "going to create an account"`]',
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/account-creation/CreatePinScreen.ts
+++ b/tests/screenobjects/account-creation/CreatePinScreen.ts
@@ -3,7 +3,6 @@ import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import { rightClickOnMacOS, rightClickOnWindows } from "@helpers/commands";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -40,7 +39,7 @@ const SELECTORS_MACOS = {
     '//XCUIElementTypeStaticText[contains(@value, "this is used to encrypt")]',
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/account-creation/CreateUserScreen.ts
+++ b/tests/screenobjects/account-creation/CreateUserScreen.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -28,7 +27,7 @@ const SELECTORS_MACOS = {
   INPUT_ERROR_TEXT: "-ios class chain:**/XCUIElementTypeStaticText",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/account-creation/EnterRecoverySeedScreen.ts
+++ b/tests/screenobjects/account-creation/EnterRecoverySeedScreen.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 import { WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -29,7 +28,7 @@ const SELECTORS_MACOS = {
   RECOVERY_SEED_TITLE_TEXT: "<Text>",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/account-creation/SaveRecoverySeedScreen.ts
+++ b/tests/screenobjects/account-creation/SaveRecoverySeedScreen.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 import { WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -27,7 +26,7 @@ const SELECTORS_MACOS = {
   I_SAVED_IT_BUTTON: "-ios class chain:**/XCUIElementTypeButton[2]",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/ChatsLayout.ts
+++ b/tests/screenobjects/chats/ChatsLayout.ts
@@ -1,8 +1,7 @@
 require("module-alias/register");
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
-import { WINDOWS_DRIVER as windowsDriver } from "@helpers/constants";
+import { WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -25,7 +24,7 @@ const SELECTORS_MACOS = {
   TYPING_INDICATOR_TEXT_VALUE: "-ios class chain:**/XCUIElementTypeStaticText",
 };
 
-currentOS === windowsDriver
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/ChatsSidebar.ts
+++ b/tests/screenobjects/chats/ChatsSidebar.ts
@@ -1,12 +1,8 @@
 require("module-alias/register");
-import {
-  MACOS_DRIVER as macDriver,
-  WINDOWS_DRIVER as windowsDriver,
-} from "@helpers/constants";
+import { WINDOWS_DRIVER } from "@helpers/constants";
 import { rightClickOnMacOS, rightClickOnWindows } from "@helpers/commands";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -83,7 +79,7 @@ const SELECTORS_MACOS = {
     "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText",
 };
 
-currentOS === windowsDriver
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/ChatsSidebar.ts
+++ b/tests/screenobjects/chats/ChatsSidebar.ts
@@ -1,5 +1,5 @@
 require("module-alias/register");
-import { WINDOWS_DRIVER } from "@helpers/constants";
+import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import { rightClickOnMacOS, rightClickOnWindows } from "@helpers/commands";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
@@ -399,9 +399,9 @@ export default class ChatsSidebar extends UplinkMainScreen {
   async getExistingElementByAriaLabel(username: string) {
     const currentDriver = await this.getCurrentDriver();
     let locator;
-    if (currentDriver === macDriver) {
+    if (currentDriver === MACOS_DRIVER) {
       locator = await $(SELECTORS.SIDEBAR).$("~" + username);
-    } else if (currentDriver === windowsDriver) {
+    } else if (currentDriver === WINDOWS_DRIVER) {
       locator = await $(SELECTORS.SIDEBAR).$('[name="' + username + '"]');
     }
     return locator;
@@ -410,9 +410,9 @@ export default class ChatsSidebar extends UplinkMainScreen {
   async getNonExistingElementByAriaLabel(username: string) {
     const currentDriver = await this.getCurrentDriver();
     let locator;
-    if (currentDriver === macDriver) {
+    if (currentDriver === MACOS_DRIVER) {
       locator = "~" + username;
-    } else if (currentDriver === windowsDriver) {
+    } else if (currentDriver === WINDOWS_DRIVER) {
       locator = '[name="' + username + '"]';
     }
     return locator;
@@ -526,9 +526,9 @@ export default class ChatsSidebar extends UplinkMainScreen {
     const imageToRightClick = await this.getSidebarUserIndicator(username);
     await this.hoverOnElement(imageToRightClick);
     const currentDriver = await this.getCurrentDriver();
-    if (currentDriver === macDriver) {
+    if (currentDriver === MACOS_DRIVER) {
       await rightClickOnMacOS(imageToRightClick);
-    } else if (currentDriver === windowsDriver) {
+    } else if (currentDriver === WINDOWS_DRIVER) {
       await rightClickOnWindows(imageToRightClick);
     }
   }
@@ -537,9 +537,9 @@ export default class ChatsSidebar extends UplinkMainScreen {
     const imageToRightClick = await this.sidebarChatsUser;
     await this.hoverOnElement(imageToRightClick);
     const currentDriver = await this.getCurrentDriver();
-    if (currentDriver === macDriver) {
+    if (currentDriver === MACOS_DRIVER) {
       await rightClickOnMacOS(imageToRightClick);
-    } else if (currentDriver === windowsDriver) {
+    } else if (currentDriver === WINDOWS_DRIVER) {
       await rightClickOnWindows(imageToRightClick);
     }
   }
@@ -549,9 +549,9 @@ export default class ChatsSidebar extends UplinkMainScreen {
       await this.getExistingElementByAriaLabel(groupName);
     await this.hoverOnElement(imageToRightClick);
     const currentDriver = await this.getCurrentDriver();
-    if (currentDriver === macDriver) {
+    if (currentDriver === MACOS_DRIVER) {
       await rightClickOnMacOS(imageToRightClick);
-    } else if (currentDriver === windowsDriver) {
+    } else if (currentDriver === WINDOWS_DRIVER) {
       await rightClickOnWindows(imageToRightClick);
     }
   }

--- a/tests/screenobjects/chats/ComposeAttachment.ts
+++ b/tests/screenobjects/chats/ComposeAttachment.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 import { WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -45,7 +44,7 @@ const SELECTORS_MACOS = {
   COMPOSE_ATTACHMENTS_MESSAGE_IMAGE_CONTAINER: "~message-image-container",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/ContextMenu.ts
+++ b/tests/screenobjects/chats/ContextMenu.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -33,7 +32,7 @@ const SELECTORS_MACOS = {
   OPEN_EMOJI_PICKER: "~open-emoji-picker",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/ContextMenuSidebar.ts
+++ b/tests/screenobjects/chats/ContextMenuSidebar.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 import { WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -26,7 +25,7 @@ const SELECTORS_MACOS = {
   SIDEBAR_CHATS_CONTEXT_LEAVE: "~chats-leave-group",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/CreateGroupChat.ts
+++ b/tests/screenobjects/chats/CreateGroupChat.ts
@@ -4,7 +4,6 @@ import { getClipboardMacOS } from "@helpers/commands";
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -54,7 +53,7 @@ const SELECTORS_MACOS = {
   USER_SEARCH_INPUT: "~friend-search-input",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/EditGroup.ts
+++ b/tests/screenobjects/chats/EditGroup.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -68,7 +67,7 @@ const SELECTORS_MACOS = {
   USER_INPUT: "~friend-search-input",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/EmojiSelector.ts
+++ b/tests/screenobjects/chats/EmojiSelector.ts
@@ -3,7 +3,6 @@ import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 import { clickOnSwitchMacOS } from "@helpers/commands";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -22,7 +21,7 @@ const SELECTORS_MACOS = {
   EMOJIS_CONTAINER: "~emojis-container",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/EmojiSuggestions.ts
+++ b/tests/screenobjects/chats/EmojiSuggestions.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 const { keyboard, Key } = require("@nut-tree/nut-js");
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -25,7 +24,7 @@ const SELECTORS_MACOS = {
   EMOJI_SUGGESTED_VALUE: "-ios class chain:**/XCUIElementTypeStaticText",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/FavoritesSidebar.ts
+++ b/tests/screenobjects/chats/FavoritesSidebar.ts
@@ -3,7 +3,6 @@ import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import { rightClickOnMacOS, rightClickOnWindows } from "@helpers/commands";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -54,7 +53,7 @@ const SELECTORS_MACOS = {
     "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/ImagePreview.ts
+++ b/tests/screenobjects/chats/ImagePreview.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import { WINDOWS_DRIVER } from "@helpers/constants";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -21,7 +20,7 @@ const SELECTORS_MACOS = {
   PREVIEW_MODAL_IMAGE_FILES: "~file-preview-image",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/InputBar.ts
+++ b/tests/screenobjects/chats/InputBar.ts
@@ -8,7 +8,6 @@ import {
 } from "@helpers/commands";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 const { keyboard, Key } = require("@nut-tree/nut-js");
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -49,7 +48,7 @@ const SELECTORS_MACOS = {
   UPLOAD_BUTTON_STORAGE: "~attach-files-from-storage-into-chat",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/MessageGroupLocal.ts
+++ b/tests/screenobjects/chats/MessageGroupLocal.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -51,7 +50,7 @@ const SELECTORS_MACOS = {
   PIN_INDICATOR: "~pin-indicator",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/MessageGroupRemote.ts
+++ b/tests/screenobjects/chats/MessageGroupRemote.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -51,7 +50,7 @@ const SELECTORS_MACOS = {
   PIN_INDICATOR: "~pin-indicator",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/MessageLocal.ts
+++ b/tests/screenobjects/chats/MessageLocal.ts
@@ -10,7 +10,6 @@ import {
 } from "@helpers/commands";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -75,7 +74,7 @@ const SELECTORS_MACOS = {
   CHAT_MESSAGE_TEXT_VALUE: "-ios class chain:**/XCUIElementTypeStaticText",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/MessageRemote.ts
+++ b/tests/screenobjects/chats/MessageRemote.ts
@@ -10,7 +10,6 @@ import {
 } from "@helpers/commands";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -77,7 +76,7 @@ const SELECTORS_MACOS = {
   CHAT_MESSAGE_TEXT_VALUE: "-ios class chain:**/XCUIElementTypeStaticText",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/OutgoingCallModal.ts
+++ b/tests/screenobjects/chats/OutgoingCallModal.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import { WINDOWS_DRIVER } from "@helpers/constants";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -47,7 +46,7 @@ const SELECTORS_MACOS = {
   USER_IMAGE_WRAP: "~user-image-wrap",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/PinnedMessages.ts
+++ b/tests/screenobjects/chats/PinnedMessages.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import { WINDOWS_DRIVER } from "@helpers/constants";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -74,7 +73,7 @@ const SELECTORS_MACOS = {
   PIN_MODAL_MAIN: "~modal",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/QuickProfile.ts
+++ b/tests/screenobjects/chats/QuickProfile.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 import { WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -58,7 +57,7 @@ const SELECTORS_MACOS = {
   QUICK_PROFILE_USER_VOLUME_RANGE_INPUT: "~range-input",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/ReplyPrompt.ts
+++ b/tests/screenobjects/chats/ReplyPrompt.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 import { WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -44,7 +43,7 @@ const SELECTORS_MACOS = {
   REPLY_POPUP_USER_IMAGE_WRAP: "~user-image-wrap",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/SendFiles.ts
+++ b/tests/screenobjects/chats/SendFiles.ts
@@ -3,7 +3,6 @@ import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import { rightClickOnMacOS, rightClickOnWindows } from "@helpers/commands";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -63,7 +62,7 @@ const SELECTORS_MACOS = {
   SEND_FILES_MODAL_SEND_BUTTON: "~send_files_modal_send_button",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/ShareDid.ts
+++ b/tests/screenobjects/chats/ShareDid.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 import { WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -43,7 +42,7 @@ const SELECTORS_MACOS = {
     "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/SidebarSearch.ts
+++ b/tests/screenobjects/chats/SidebarSearch.ts
@@ -1,8 +1,7 @@
 require("module-alias/register");
-import { WINDOWS_DRIVER as windowsDriver } from "@helpers/constants";
+import { WINDOWS_DRIVER } from "@helpers/constants";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -65,7 +64,7 @@ const SELECTORS_MACOS = {
   SIDEBAR_SEARCH_USER_RESULT: "~search-result-user",
 };
 
-currentOS === windowsDriver
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/chats/Topbar.ts
+++ b/tests/screenobjects/chats/Topbar.ts
@@ -1,7 +1,6 @@
 require("module-alias/register");
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -55,7 +54,7 @@ const SELECTORS_MACOS = {
   TOPBAR_VIDEOCALL: "~Videocall",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/files/FilesScreen.ts
+++ b/tests/screenobjects/files/FilesScreen.ts
@@ -12,7 +12,6 @@ import {
 } from "@helpers/commands";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -113,7 +112,7 @@ const SELECTORS_MACOS = {
   UPLOAD_PROGRESS_BAR_HEADER_PERCENTAGE: "~upload-progress-percentage",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/friends/FriendsScreen.ts
+++ b/tests/screenobjects/friends/FriendsScreen.ts
@@ -8,7 +8,6 @@ import {
   rightClickOnWindows,
 } from "@helpers/commands";
 
-const currentOS = driver.capabilities.automationName;
 const { keyboard, Key } = require("@nut-tree/nut-js");
 
 let SELECTORS = {};
@@ -139,7 +138,7 @@ const SELECTORS_MACOS = {
   TOPBAR: "~Topbar",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/settings/CropToolProfileModal.ts
+++ b/tests/screenobjects/settings/CropToolProfileModal.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import { WINDOWS_DRIVER } from "@helpers/constants";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -39,7 +38,7 @@ const SELECTORS_MACOS = {
   CROP_IMAGE_TOPBAR_LABEL_TEXT: "-ios class chain:**/XCUIElementTypeStaticText",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/settings/SettingsAboutScreen.ts
+++ b/tests/screenobjects/settings/SettingsAboutScreen.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import SettingsBaseScreen from "@screenobjects/settings/SettingsBaseScreen";
 import { WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -47,7 +46,7 @@ const SELECTORS_MACOS = {
   SETTINGS_INFO_HEADER: "-ios class chain:**/XCUIElementTypeStaticText[1]",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/settings/SettingsAccessibilityScreen.ts
+++ b/tests/screenobjects/settings/SettingsAccessibilityScreen.ts
@@ -3,7 +3,6 @@ import { clickOnSwitchMacOS } from "@helpers/commands";
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import SettingsBaseScreen from "@screenobjects/settings/SettingsBaseScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -31,7 +30,7 @@ const SELECTORS_MACOS = {
   SWITCH_SLIDER: "~Switch Slider",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/settings/SettingsAudioScreen.ts
+++ b/tests/screenobjects/settings/SettingsAudioScreen.ts
@@ -3,7 +3,6 @@ import { clickOnSwitchMacOS } from "@helpers/commands";
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import SettingsBaseScreen from "@screenobjects/settings/SettingsBaseScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -44,7 +43,7 @@ const SELECTORS_MACOS = {
   SWITCH_SLIDER: "~Switch Slider",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/settings/SettingsBaseScreen.ts
+++ b/tests/screenobjects/settings/SettingsBaseScreen.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -37,7 +36,7 @@ const SELECTORS_MACOS = {
   SETTINGS_SEARCH_INPUT: "~settings-search-input",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 
@@ -47,7 +46,7 @@ export default class SettingsBaseScreen extends UplinkMainScreen {
   }
 
   async getCurrentDriver() {
-    const currentDriver = await driver.capabilities.automationName;
+    const currentDriver = process.env.DRIVER;
     return currentDriver;
   }
 

--- a/tests/screenobjects/settings/SettingsDeveloperScreen.ts
+++ b/tests/screenobjects/settings/SettingsDeveloperScreen.ts
@@ -7,7 +7,6 @@ import {
   WINDOWS_DRIVER,
 } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -45,7 +44,7 @@ const SELECTORS_MACOS = {
   TEST_NOTIFICATIONS_BUTTON: "~test-notifications-button",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/settings/SettingsExtensionsScreen.ts
+++ b/tests/screenobjects/settings/SettingsExtensionsScreen.ts
@@ -3,7 +3,6 @@ import { clickOnSwitchMacOS } from "@helpers/commands";
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import SettingsBaseScreen from "@screenobjects/settings/SettingsBaseScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -70,7 +69,7 @@ const SELECTORS_MACOS = {
   SWITCH_SLIDER_VALUE: "~switch-slider-value",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/settings/SettingsGeneralScreen.ts
+++ b/tests/screenobjects/settings/SettingsGeneralScreen.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import SettingsBaseScreen from "@screenobjects/settings/SettingsBaseScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -59,7 +58,7 @@ const SELECTORS_MACOS = {
     "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/settings/SettingsLicenses.ts
+++ b/tests/screenobjects/settings/SettingsLicenses.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import SettingsBaseScreen from "@screenobjects/settings/SettingsBaseScreen";
 import { WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -28,7 +27,7 @@ const SELECTORS_MACOS = {
   SETTINGS_SECTION: "~settings-section",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/settings/SettingsMessagesScreen.ts
+++ b/tests/screenobjects/settings/SettingsMessagesScreen.ts
@@ -3,7 +3,6 @@ import { clickOnSwitchMacOS } from "@helpers/commands";
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import SettingsBaseScreen from "@screenobjects/settings/SettingsBaseScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -31,7 +30,7 @@ const SELECTORS_MACOS = {
   SWITCH_SLIDER: "~Switch Slider",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/settings/SettingsNotificationsScreen.ts
+++ b/tests/screenobjects/settings/SettingsNotificationsScreen.ts
@@ -3,7 +3,6 @@ import { clickOnSwitchMacOS } from "@helpers/commands";
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import SettingsBaseScreen from "@screenobjects/settings/SettingsBaseScreen";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {
@@ -31,7 +30,7 @@ const SELECTORS_MACOS = {
   SWITCH_SLIDER: "~Switch Slider",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/settings/SettingsProfileScreen.ts
+++ b/tests/screenobjects/settings/SettingsProfileScreen.ts
@@ -12,7 +12,6 @@ import {
 import { MACOS_DRIVER, WINDOWS_DRIVER } from "@helpers/constants";
 import SettingsBaseScreen from "@screenobjects/settings/SettingsBaseScreen";
 
-const currentOS = driver.capabilities.automationName;
 const { keyboard, Key } = require("@nut-tree/nut-js");
 let SELECTORS = {};
 
@@ -93,7 +92,7 @@ const SELECTORS_MACOS = {
     "-ios class chain:**/XCUIElementTypeStaticText",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/screenobjects/welcome-screen/WelcomeScreen.ts
+++ b/tests/screenobjects/welcome-screen/WelcomeScreen.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import UplinkMainScreen from "@screenobjects/UplinkMainScreen";
 import { WINDOWS_DRIVER } from "@helpers/constants";
 
-const currentOS = driver.capabilities.automationName;
 let SELECTORS = {};
 
 const SELECTORS_COMMON = {};
@@ -21,7 +20,7 @@ const SELECTORS_MACOS = {
   WELCOME_LAYOUT: "~welcome-screen",
 };
 
-currentOS === WINDOWS_DRIVER
+process.env.DRIVER === WINDOWS_DRIVER
   ? (SELECTORS = { ...SELECTORS_WINDOWS, ...SELECTORS_COMMON })
   : (SELECTORS = { ...SELECTORS_MACOS, ...SELECTORS_COMMON });
 

--- a/tests/suites/Chats/01-Chats.suite.ts
+++ b/tests/suites/Chats/01-Chats.suite.ts
@@ -17,9 +17,9 @@ describe("Message Context Menu Tests", messageContextMenuTests.bind(this));
 describe("Message Input Tests", messageInputTests.bind(this));
 describe("Message Attachments Tests", messageAttachmentsTests.bind(this));
 describe("Chat Topbar Tests", chatTopbarTests.bind(this));
-xdescribe("Quick Profile Tests", quickProfileTests.bind(this));
-xdescribe("Sidebar Chats Tests", sidebarChatsTests.bind(this));
-xdescribe("Group Chats Tests", groupChatTests.bind(this));
+describe("Quick Profile Tests", quickProfileTests.bind(this));
+describe("Sidebar Chats Tests", sidebarChatsTests.bind(this));
+describe("Group Chats Tests", groupChatTests.bind(this));
 xdescribe("Group Chats Edit Tests", groupChatEditTests.bind(this));
 xdescribe(
   "Group Chats Favorites and Sidebar Tests",


### PR DESCRIPTION
### What this PR does 📖

- Use env variable DRIVER to pass the current driver, instead of getting it from capabilities in order to improve execution times and useful for attempting independent test execution for spec files

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
