### PR TITLE
test(add): refactor tests for creating account

### DIFF
--- a/tests/screenobjects/account-creation/CreateOrImportScreen.ts
+++ b/tests/screenobjects/account-creation/CreateOrImportScreen.ts
@@ -9,7 +9,7 @@ const SELECTORS_COMMON = {};
 const SELECTORS_WINDOWS = {
   CREATE_NEW_ACCOUNT_BUTTON: '[name="create-button"]',
   CREATE_OR_RECOVER_LABEL: '[name="create-or-recover"]',
-  CREATE_OR_RECOVER_LABEL_TEXT: "<Text>",
+  CREATE_OR_RECOVER_LABEL_TEXT: '//Text[@Name="ACCOUNT CREATION"]',
   IMPORT_ACCOUNT_BUTTON: '[name="recover-button"]',
   RECOVERY_LAYOUT: '[name="create-or-recover-layout"]',
   RECOVERY_PARAGRAPH: '[name="create-or-recover-instructions"]',

--- a/tests/screenobjects/account-creation/CreateUserScreen.ts
+++ b/tests/screenobjects/account-creation/CreateUserScreen.ts
@@ -48,6 +48,10 @@ export default class CreateUserScreen extends UplinkMainScreen {
     return this.createUserHelper.$(SELECTORS.CREATE_USER_HELPER_TEXT);
   }
 
+  get createUserLabelText() {
+    return this.unlockLayout.$(SELECTORS.CREATE_USER_LABEL_TEXT);
+  }
+
   get inputError() {
     return $(SELECTORS.INPUT_ERROR);
   }

--- a/tests/screenobjects/account-creation/SaveRecoverySeedScreen.ts
+++ b/tests/screenobjects/account-creation/SaveRecoverySeedScreen.ts
@@ -10,7 +10,7 @@ const SELECTORS_WINDOWS = {
   COPY_SEED_HELPER_TEXT:
     '//Group/Text[contains(@Name, "Write these words down")]',
   COPY_SEED_WORDS_LABEL: '[name="copy-seed-words"]',
-  COPY_SEED_WORDS_LABEL_TEXT: "<Text>>",
+  COPY_SEED_WORDS_LABEL_TEXT: '//Text[@Name="RECOVERY SEED"]',
   COPY_SEED_WORDS_LAYOUT: '[name="copy-seed-words-layout"]',
   GO_BACK_BUTTON: '[name="back-button"]',
   I_SAVED_IT_BUTTON: '[name="i-saved-it-button"]',

--- a/tests/screenobjects/chats/ChatsLayout.ts
+++ b/tests/screenobjects/chats/ChatsLayout.ts
@@ -11,7 +11,7 @@ const SELECTORS_COMMON = {
 const SELECTORS_WINDOWS = {
   ENCRYPTED_MESSAGES: '[name="messages-secured-alert"]',
   ENCRYPTED_MESSAGES_TEXT: "//Group/Text",
-  SCROLL_TO_BOTTOM: '//Text[@value="Scroll to bottom"]',
+  SCROLL_TO_BOTTOM: '//Text[@Name="Scroll to bottom"]',
   TYPING_INDICATOR: '[name="message-typing-indicator"]',
   TYPING_INDICATOR_TEXT: '[name="typing-message"]',
   TYPING_INDICATOR_TEXT_VALUE: "<Text>",

--- a/tests/specs/01-create-account.spec.ts
+++ b/tests/specs/01-create-account.spec.ts
@@ -139,7 +139,6 @@ export default async function createAccountTests() {
 
     // Validate 12 recovery seed words are displayed on screen
     const seedWords = await saveRecoverySeed.getSeedWords();
-    console.log(seedWords);
     await expect(seedWords.length).toEqual(12);
   });
 

--- a/tests/specs/01-create-account.spec.ts
+++ b/tests/specs/01-create-account.spec.ts
@@ -124,12 +124,6 @@ export default async function createAccountTests() {
       "We're going to create an account for you. On the next screen, you'll see a set of words. Screenshot this or write it down. This is the only way to backup your account.",
     );
     await expect(createOrImportHeader).toHaveTextContaining("ACCOUNT CREATION");
-
-    const createNewAccountButton = await createOrImport.createNewAccountButton;
-    const importAccountButton = await createOrImport.importAccountButton;
-    await createNewAccountButton.waitForDisplayed();
-    await importAccountButton.waitForDisplayed();
-
     await createOrImport.clickOnCreateAccount();
   });
 

--- a/tests/specs/01-create-account.spec.ts
+++ b/tests/specs/01-create-account.spec.ts
@@ -12,7 +12,7 @@ const saveRecoverySeed = new SaveRecoverySeedScreen();
 const welcomeScreen = new WelcomeScreen();
 
 export default async function createAccountTests() {
-  it("Validate warning texts are displayed on screen", async () => {
+  it("Enter Pin Screen - Validate warning texts are displayed on screen", async () => {
     const unlockWarningHeader = await createPin.unlockWarningHeader;
     await unlockWarningHeader.waitForExist();
     await expect(unlockWarningHeader).toHaveTextContaining([
@@ -27,13 +27,13 @@ export default async function createAccountTests() {
     );
   });
 
-  it("Create Account button should be disabled if no pin has been entered", async () => {
+  it("Enter Pin Screen - Create Account button should be disabled if no pin has been entered", async () => {
     const statusOfButton = await createPin.getStatusOfCreateAccountButton();
     await expect(statusOfButton).toEqual("false");
   });
 
   // Skipping test failing on CI
-  xit("Unlock Screen - Help Button Tooltip", async () => {
+  xit("Enter Pin Screen -  - Help Button Tooltip", async () => {
     // Wait until app is reset
     await createPin.unlockWarningHeader.waitForExist();
 
@@ -46,7 +46,7 @@ export default async function createAccountTests() {
     );
   });
 
-  it("Unlock Screen - Reset Account is shown after right clicking on Help Button", async () => {
+  it("Enter Pin Screen - Reset Account is shown after right clicking on Help Button", async () => {
     // Right click on Help Button to show the help menu
     await createPin.openHelpButtonMenu();
 
@@ -54,7 +54,7 @@ export default async function createAccountTests() {
     await createPin.openHelpButtonMenu();
   });
 
-  it("Enter an empty pin", async () => {
+  it("Enter Pin Screen - Enter an empty pin", async () => {
     await createPin.unlockWarningParagraph.waitForExist();
     await createPin.enterPin("1");
 
@@ -69,7 +69,7 @@ export default async function createAccountTests() {
     await expect(statusOfButton).toEqual("false");
   });
 
-  it("Enter a pin with less than 4 characters", async () => {
+  it("Enter Pin Screen - Enter a pin with less than 4 characters", async () => {
     await createPin.enterPin("123");
     await createPin.inputError.waitForExist();
     const inputErrorText = await createPin.inputErrorText;
@@ -82,7 +82,7 @@ export default async function createAccountTests() {
   });
 
   // Skipping test failing when appium stops typing
-  xit("Enter a pin with more than 32 characters", async () => {
+  xit("Enter Pin Screen - Enter a pin with more than 32 characters", async () => {
     await createPin.enterPin("12345678901234567890123456789012");
 
     await createPin.inputError.waitForExist();
@@ -96,7 +96,7 @@ export default async function createAccountTests() {
   });
 
   // Skipping test failing when appium stops typing
-  xit("Enter a pin with spaces", async () => {
+  xit("Enter Pin Screen - Enter a pin with spaces", async () => {
     // Enter pin value with spaces
     await createPin.pinInput.click();
     await createPin.enterPin("1234" + "   ");
@@ -108,22 +108,71 @@ export default async function createAccountTests() {
     await createPin.pinInput.clearValue();
   });
 
-  it("Enter a valid pin and continue creating a username", async () => {
+  it("Enter Pin Screen - Enter a valid pin and continue creating a username", async () => {
     await createPin.enterPin("1234");
     const statusOfButton = await createPin.getStatusOfCreateAccountButton();
     await expect(statusOfButton).toEqual("true");
     await createPin.clickOnCreateAccount();
   });
 
-  it("Create or Import Account Screen - Click on Create New Account and save receovery seed", async () => {
+  it("Create or Import Account - Validate screen contents and click on Create New Account", async () => {
     await createOrImport.waitForIsShown(true);
+
+    const instructionsParagraph = await createOrImport.recoveryParagraphText;
+    const createOrImportHeader = await createOrImport.createOrRecoverLabelText;
+    await expect(instructionsParagraph).toHaveTextContaining(
+      "We're going to create an account for you. On the next screen, you'll see a set of words. Screenshot this or write it down. This is the only way to backup your account.",
+    );
+    await expect(createOrImportHeader).toHaveTextContaining("ACCOUNT CREATION");
+
+    const createNewAccountButton = await createOrImport.createNewAccountButton;
+    const importAccountButton = await createOrImport.importAccountButton;
+    await createNewAccountButton.waitForDisplayed();
+    await importAccountButton.waitForDisplayed();
+
     await createOrImport.clickOnCreateAccount();
+  });
+
+  it("Save Recovery Seed Screen - Contents validation", async () => {
+    // Validate contents of Save Recovery Seed Screen
+    await saveRecoverySeed.waitForIsShown(true);
+    const helperText = await saveRecoverySeed.copySeedHelperText;
+    const copySeedTitle = await saveRecoverySeed.copySeedWordsLabelText;
+    await expect(helperText).toHaveTextContaining(
+      "Write these words down in the order that they appear. Having the correct order is crucial when you are recovering your account.",
+    );
+    await expect(copySeedTitle).toHaveTextContaining("RECOVERY SEED");
+
+    // Validate 12 recovery seed words are displayed on screen
+    const seedWords = await saveRecoverySeed.getSeedWords();
+    console.log(seedWords);
+    await expect(seedWords.length).toEqual(12);
+  });
+
+  it("Save Recovery Seed Screen - User can go back to previous screen", async () => {
+    // Go Back to Create or Import Account screen
+    await saveRecoverySeed.clickOnGoBackButton();
+    await createOrImport.waitForIsShown(true);
+
+    // Return to Save Recovery Seed Screen
+    await createOrImport.clickOnCreateAccount();
+  });
+
+  it("Save Recovery Seed Screen - User can click on I Saved It to continue", async () => {
+    // Click on I Saved It Button to continue to Enter Username Screen
     await saveRecoverySeed.waitForIsShown(true);
     await saveRecoverySeed.clickOnISavedItButton();
     await createUser.waitForIsShown(true);
   });
 
-  it("Leave empty username and attempt to continue", async () => {
+  it("Enter Username Screen - Cannot continue with empty value", async () => {
+    const helperText = await createUser.createUserHelperText;
+    const headerText = await createUser.createUserLabelText;
+    await expect(helperText).toHaveTextContaining(
+      "Time to pick your username, you can change this later at any time in settings.",
+    );
+    await expect(headerText).toHaveTextContaining("ENTER USERNAME");
+
     await createUser.enterUsername("1");
     await createUser.enterUsername("");
     const statusOfButton = await createPin.getStatusOfCreateAccountButton();
@@ -136,7 +185,7 @@ export default async function createAccountTests() {
     );
   });
 
-  it("Username with less than 4 characters and attempt to continue", async () => {
+  it("Enter Username Screen - Username with less than 4 characters and attempt to continue", async () => {
     await createUser.enterUsername("12");
     const statusOfButton = await createPin.getStatusOfCreateAccountButton();
     await expect(statusOfButton).toEqual("false");
@@ -148,7 +197,7 @@ export default async function createAccountTests() {
     );
   });
 
-  it("Username with more than 32 characters and attempt to continue", async () => {
+  it("Enter Username Screen - Username with more than 32 characters and attempt to continue", async () => {
     await createUser.enterUsername("123456789012345678901234567890123");
     const statusOfButton = await createPin.getStatusOfCreateAccountButton();
     await expect(statusOfButton).toEqual("false");
@@ -160,7 +209,7 @@ export default async function createAccountTests() {
     );
   });
 
-  it("Username with spaces and attempt to continue", async () => {
+  it("Enter Username Screen - Username with spaces and attempt to continue", async () => {
     // Enter pin value with spaces
     await createUser.usernameInput.click();
     await createUser.enterUsername("1234" + "             ");
@@ -172,7 +221,7 @@ export default async function createAccountTests() {
     await expect(inputErrorText).toHaveText("Spaces are not allowed.");
   });
 
-  it("Username with non-alphanumeric characters", async () => {
+  it("Enter Username Screen - Username with non-alphanumeric characters", async () => {
     await createUser.enterUsername("test..%@");
     const statusOfButton = await createPin.getStatusOfCreateAccountButton();
     await expect(statusOfButton).toEqual("false");
@@ -184,7 +233,7 @@ export default async function createAccountTests() {
     );
   });
 
-  it("Enter valid username to continue", async () => {
+  it("Enter Username Screen - Enter valid username to continue", async () => {
     await createUser.enterUsername("Test123");
     const statusOfButton = await createPin.getStatusOfCreateAccountButton();
     await expect(statusOfButton).toEqual("true");


### PR DESCRIPTION
### What this PR does 📖

- Refactor tests for create account to state which screens are validating
- Adding tests for Create or Import Account, Save Recovery Seed Screens and added missing tests on Enter Username screen

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
