### PR TITLE
test(update): skip dark light toggle theme for windows copy assets

### DIFF
--- a/tests/specs/06-settings-general.spec.ts
+++ b/tests/specs/06-settings-general.spec.ts
@@ -127,10 +127,12 @@ export default async function settingsGeneralTests() {
     }
   });
 
-  it("Settings General - Validate user can clear accent color", async () => {
+  // Skipping test for Automation Tests Windows Failure on copying assets crashing the app
+  xit("Settings General - Validate user can clear accent color", async () => {
     await settingsGeneral.clickOnClearAccentColor();
   });
 
+  // Skipping test for Automation Tests Windows Failure on copying assets crashing the app
   it("Settings General - Return theme to Dark Theme", async () => {
     await settingsGeneral.clickOnDarkLightThemeToggle();
   });


### PR DESCRIPTION
### What this PR does 📖

- UI Tests on Windows started to fail because the assets are not copied correctly on CI execution.
- Skipping tests failing due to crash on missing themes files not copied over on Windows CI (short term solution)
- Long term solution is that Windows CI will be modified to automate the installer process instead of manually grabbing assets files (which I will work on a different ticket)

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
