### PR TITLE
chore(warp): update warp ref id on tests

### DIFF
--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Satellite-im/Warp
-          ref: 96f96fc9853112133cd592a5bb233fb36ecd9a01
+          ref: 0a216237cb9c965754df444b80ea983879831396
 
       - name: Set up cargo cache 🛠️
         uses: Swatinem/rust-cache@v2
@@ -212,7 +212,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Satellite-im/Warp
-          ref: 96f96fc9853112133cd592a5bb233fb36ecd9a01
+          ref: 0a216237cb9c965754df444b80ea983879831396
           path: "./warp"
 
       - name: Download Key file 🗳️
@@ -343,7 +343,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Satellite-im/Warp
-          ref: 96f96fc9853112133cd592a5bb233fb36ecd9a01
+          ref: 0a216237cb9c965754df444b80ea983879831396
           path: "./warp"
 
       - name: Download Key file 🗳️
@@ -473,7 +473,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Satellite-im/Warp
-          ref: 96f96fc9853112133cd592a5bb233fb36ecd9a01
+          ref: 0a216237cb9c965754df444b80ea983879831396
           path: "./warp"
 
       - name: Download Key file 🗳️

--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Satellite-im/Warp
-          ref: 32f4c53fc462d53553a31762ecd12b4af9329a4a
+          ref: 96f96fc9853112133cd592a5bb233fb36ecd9a01
 
       - name: Set up cargo cache 🛠️
         uses: Swatinem/rust-cache@v2
@@ -212,7 +212,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Satellite-im/Warp
-          ref: 32f4c53fc462d53553a31762ecd12b4af9329a4a
+          ref: 96f96fc9853112133cd592a5bb233fb36ecd9a01
           path: "./warp"
 
       - name: Download Key file 🗳️
@@ -343,7 +343,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Satellite-im/Warp
-          ref: 32f4c53fc462d53553a31762ecd12b4af9329a4a
+          ref: 96f96fc9853112133cd592a5bb233fb36ecd9a01
           path: "./warp"
 
       - name: Download Key file 🗳️
@@ -473,7 +473,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Satellite-im/Warp
-          ref: 32f4c53fc462d53553a31762ecd12b4af9329a4a
+          ref: 96f96fc9853112133cd592a5bb233fb36ecd9a01
           path: "./warp"
 
       - name: Download Key file 🗳️


### PR DESCRIPTION
### What this PR does 📖

- Update ref commit ID when checking out warp to latest value from https://github.com/Satellite-im/Uplink/pull/1839

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
