### PR TITLE
test(add): add tests for changing and restoring keybinds

### DIFF
--- a/tests/helpers/commands.ts
+++ b/tests/helpers/commands.ts
@@ -524,14 +524,11 @@ export async function sendCustomKeybinds(...keys: number[]) {
   // To find the number associated for each key to send on keybind, refer to node_modules/@nut-tree/nut-js/dist/lib/key.enum.d.ts
   for (let i = 0; i < keys.length - 1; i++) {
     await keyboard.pressKey(keys[i]);
-    console.log("Pressed key: " + keys[i]);
   }
 
   await keyboard.type(keys[keys.length - 1]);
-  console.log("Typed key: " + keys[keys.length - 1]);
 
   for (let i = keys.length - 2; i >= 0; i--) {
     await keyboard.releaseKey(keys[i]);
-    console.log("Released key: " + keys[i]);
   }
 }

--- a/tests/helpers/commands.ts
+++ b/tests/helpers/commands.ts
@@ -18,7 +18,7 @@ import {
 const { readFileSync, rmSync, writeFileSync } = require("fs");
 const { execSync } = require("child_process");
 const fsp = require("fs").promises;
-const { clipboard, keyboard, Key, mouse, Button } = require("@nut-tree/nut-js");
+const { clipboard, keyboard, mouse, Button } = require("@nut-tree/nut-js");
 const createOrImport = new CreateOrImportScreen();
 let createPin = new CreatePinScreen();
 let createUser = new CreateUserScreen();

--- a/tests/helpers/commands.ts
+++ b/tests/helpers/commands.ts
@@ -26,6 +26,8 @@ let friendsScreen = new FriendsScreen();
 const saveRecoverySeed = new SaveRecoverySeedScreen();
 let welcomeScreen = new WelcomeScreen();
 
+export type MyKey = keyof typeof CustomKey;
+
 // Users cache helper functions
 
 export async function deleteCache() {
@@ -505,15 +507,31 @@ export async function getUplinkWindowHandle() {
 // Key Combinations Commands
 
 export async function keyboardShortcutPaste() {
-  await keyboard.type(Key.LeftControl, Key.V);
+  await keyboard.type(4, 66);
 }
 
 export async function keyboardShiftEnter() {
-  await keyboard.pressKey(Key.LeftShift);
-  await keyboard.type(Key.Enter);
-  await keyboard.releaseKey(Key.LeftShift);
+  await keyboard.pressKey(7);
+  await keyboard.type(101);
+  await keyboard.releaseKey(7);
 }
 
 export async function pressEscKey() {
-  await keyboard.type(Key.Escape);
+  await keyboard.type(1);
+}
+
+export async function sendCustomKeybinds(...keys: number[]) {
+  // To find the number associated for each key to send on keybind, refer to node_modules/@nut-tree/nut-js/dist/lib/key.enum.d.ts
+  for (let i = 0; i < keys.length - 1; i++) {
+    await keyboard.pressKey(keys[i]);
+    console.log("Pressed key: " + keys[i]);
+  }
+
+  await keyboard.type(keys[keys.length - 1]);
+  console.log("Typed key: " + keys[keys.length - 1]);
+
+  for (let i = keys.length - 2; i >= 0; i--) {
+    await keyboard.releaseKey(keys[i]);
+    console.log("Released key: " + keys[i]);
+  }
 }

--- a/tests/screenobjects/settings/SettingsKeybindsScreen.ts
+++ b/tests/screenobjects/settings/SettingsKeybindsScreen.ts
@@ -478,4 +478,20 @@ export default class SettingsKeybindsScreen extends SettingsBaseScreen {
     const revertButton = await this.toggleMuteResetKeybindButton;
     await revertButton.click();
   }
+
+  // Edit Keybinds
+  async editKeybind(section: Keybinds) {
+    let sectionToEdit;
+    const currentDriver = await this.getCurrentDriver();
+    if (currentDriver === MACOS_DRIVER) {
+      sectionToEdit = await $(`~${section}-section`).$(
+        SELECTORS.KEYBIND_SECTION_KEYS,
+      );
+    } else if (currentDriver === WINDOWS_DRIVER) {
+      sectionToEdit = await $(`[name="${section}-section"]`).$(
+        SELECTORS.KEYBIND_SECTION_KEYS,
+      );
+    }
+    await sectionToEdit?.click();
+  }
 }

--- a/tests/specs/18-settings-keybinds.spec.ts
+++ b/tests/specs/18-settings-keybinds.spec.ts
@@ -155,15 +155,15 @@ export default async function settingsKeybindsTests() {
     // Now, change Hide/Focus Uplink Keybind by typing Ctrl + Shift + U
     await sendCustomKeybinds(4, 7, 65);
     await settingsKeybinds.editKeybind("hide-focus-uplink");
-    // Type Ctrl + Alt + Shift + P
-    await sendCustomKeybinds(4, 3, 7, 60);
+    // Type Alt + Ctrl + Shift + P
+    await sendCustomKeybinds(3, 4, 7, 60);
 
     // Validate change was applied correctly to Hide/Focus Uplink Keybind
     const hideFocusUplinkKeybind =
       await settingsKeybinds.getKeybinds("hide-focus-uplink");
     await expect(hideFocusUplinkKeybind).toEqual([
-      "CONTROL",
       "ALT",
+      "CONTROL",
       "SHIFT",
       "P",
     ]);

--- a/tests/specs/18-settings-keybinds.spec.ts
+++ b/tests/specs/18-settings-keybinds.spec.ts
@@ -1,4 +1,5 @@
 require("module-alias/register");
+import { sendCustomKeybinds } from "@helpers/commands";
 import { MACOS_DRIVER } from "@helpers/constants";
 import SettingsExtensionsScreen from "@screenobjects/settings/SettingsExtensionsScreen";
 import SettingsKeybindsScreen from "@screenobjects/settings/SettingsKeybindsScreen";
@@ -118,5 +119,76 @@ export default async function settingsKeybindsTests() {
     const hideFocusUplinkKeybind =
       await settingsKeybinds.getKeybinds("hide-focus-uplink");
     await expect(hideFocusUplinkKeybind).toEqual(["CONTROL", "SHIFT", "U"]);
+  });
+
+  it("Settings Keyboards Shortcuts - Change Increase Font Size Keybind", async () => {
+    // Type Ctrl + Shift + =
+    await sendCustomKeybinds(4, 7, 73);
+    await settingsKeybinds.editKeybind("increase-font-size");
+    // Type Ctrl + A
+    await sendCustomKeybinds(4, 45);
+
+    const increaseFontSizeKeybind =
+      await settingsKeybinds.getKeybinds("increase-font-size");
+    await expect(increaseFontSizeKeybind).toEqual(["CONTROL", "A"]);
+  });
+
+  it("Settings Keyboards Shortcuts - Reset Increase Font Size Keybind", async () => {
+    await settingsKeybinds.clickOnRevertIncreaseFontSize();
+    const increaseFontSizeKeybind =
+      await settingsKeybinds.getKeybinds("increase-font-size");
+    await expect(increaseFontSizeKeybind).toEqual(["CONTROL", "SHIFT", "="]);
+  });
+
+  it("Settings Keyboards Shortcuts - User can update more than one keybind", async () => {
+    // Change at least two different keybinds. First, change Decrease Font Size Keybind, by typing Ctrl + Shift + -
+    await sendCustomKeybinds(4, 7, 72);
+    // Edit Decrease Font Size Keybind to Ctrl + B
+    await settingsKeybinds.editKeybind("decrease-font-size");
+    await sendCustomKeybinds(4, 46);
+
+    // Validate change was applied correctly to Decrease Font Size Keybind
+    const decreaseFontSizeKeybind =
+      await settingsKeybinds.getKeybinds("decrease-font-size");
+    await expect(decreaseFontSizeKeybind).toEqual(["CONTROL", "B"]);
+
+    // Now, change Hide/Focus Uplink Keybind by typing Ctrl + Shift + U
+    await sendCustomKeybinds(4, 7, 65);
+    await settingsKeybinds.editKeybind("hide-focus-uplink");
+    // Type Ctrl + Alt + Shift + P
+    await sendCustomKeybinds(4, 3, 7, 60);
+
+    // Validate change was applied correctly to Hide/Focus Uplink Keybind
+    const hideFocusUplinkKeybind =
+      await settingsKeybinds.getKeybinds("hide-focus-uplink");
+    await expect(hideFocusUplinkKeybind).toEqual([
+      "CONTROL",
+      "ALT",
+      "SHIFT",
+      "P",
+    ]);
+  });
+
+  it("Settings Keyboards Shortcuts - User can revert all Keybinds to Default Values", async () => {
+    // Click on Revert all keybinds
+    await settingsKeybinds.clickOnRevertAllKeybinds();
+
+    // Validate default keys are assigned for Decrease Font Size Keybind (Ctrl + Shift + -)
+    const decreaseFontSizeKeybindDefault =
+      await settingsKeybinds.getKeybinds("decrease-font-size");
+    await expect(decreaseFontSizeKeybindDefault).toEqual([
+      "CONTROL",
+      "SHIFT",
+      "-",
+    ]);
+
+    // Validate default keys are assigned for Hide/Show Uplink Keybind (Ctrl + Shift + U)
+    const hideFocusUplinkKeybindDefault =
+      await settingsKeybinds.getKeybinds("hide-focus-uplink");
+    await expect(hideFocusUplinkKeybindDefault).toEqual([
+      "CONTROL",
+      "SHIFT",
+      "U",
+    ]);
   });
 }


### PR DESCRIPTION
### What this PR does 📖

- Add tests for changing keybinds and restoring default keybinds
- Implementing a custom command for sending keybinds that can be used for different type of combinations (2, 3 or more keys)
- Passing number value of keys for keybinds commands

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
