### PR TITLE
test(update): use launch instead of activate app

### DIFF
--- a/tests/specs/reusable-accounts/01-create-accounts-and-friends.spec.ts
+++ b/tests/specs/reusable-accounts/01-create-accounts-and-friends.spec.ts
@@ -1,9 +1,8 @@
 require("module-alias/register");
 import {
-  activateFirstApplication,
-  activateSecondApplication,
   createNewUser,
   getUserKey,
+  launchFirstApplication,
   launchSecondApplication,
   saveTestKeys,
 } from "@helpers/commands";
@@ -148,7 +147,7 @@ export default async function createChatAccountsTests() {
 
   it("Chat User A - Accept friend request from User A and go to chat button", async () => {
     // Switch control to User A
-    await activateFirstApplication();
+    await launchFirstApplication();
 
     // With User A - Go to pending requests list, wait for receiving the friend request and accept it
     await friendsScreen.hoverOnPendingListButton();
@@ -168,7 +167,7 @@ export default async function createChatAccountsTests() {
 
   it("Chat User B - Validate friend request was accepted", async () => {
     // Switch control to User B
-    await activateSecondApplication();
+    await launchSecondApplication();
 
     // With User B - Go to pending requests list, wait for receiving the friend request and accept it
     await friendsScreen.waitUntilUserAcceptedFriendRequest();
@@ -181,7 +180,7 @@ export default async function createChatAccountsTests() {
 
   it("Chat User A - Chat screen displays Messages secured text displayed on top of conversation", async () => {
     // Switch control to User A
-    await activateFirstApplication();
+    await launchFirstApplication();
     await chatsTopbar.validateTopbarExists();
 
     // Validate E2E message is displayed on top of chat
@@ -281,7 +280,7 @@ export default async function createChatAccountsTests() {
 
   it("Chat User B - Wait until the other user is connected", async () => {
     // Switch control to User B
-    await activateSecondApplication();
+    await launchSecondApplication();
 
     // Go to the current list of All friends and then open a Chat conversation with ChatUserA
     await friendsScreen.chatWithFriendButton.waitForExist();


### PR DESCRIPTION
### What this PR does 📖

- Attempt to use launch app instead of activate app to reduce the random crash failures happening with appium on chats tests

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
