### PR TITLE
screenobject(update): change aria labels for context menu

### DIFF
--- a/tests/screenobjects/friends/FriendsScreen.ts
+++ b/tests/screenobjects/friends/FriendsScreen.ts
@@ -32,8 +32,8 @@ const SELECTORS_WINDOWS = {
   CONTEXT_MENU: '[name="Context Menu"]',
   CONTEXT_MENU_BLOCK: '[name="friends-block"]',
   CONTEXT_MENU_CHAT: '[name="friends-chat"]',
-  CONTEXT_MENU_COPY_DID_KEY: '//Button[@Name="copy-id-context"][2]',
-  CONTEXT_MENU_COPY_ID: '//Button[@Name="copy-id-context"][1]',
+  CONTEXT_MENU_COPY_DID_KEY: "//Button[2]",
+  CONTEXT_MENU_COPY_ID: "//Button[1]",
   CONTEXT_MENU_FAVORITES_ADD: '[name="favorites-add"]',
   CONTEXT_MENU_FAVORITES_REMOVE: '[name="favorites-remove"]',
   CONTEXT_MENU_INCOMING_ACCEPT: '[name="friends-accept"]',
@@ -91,10 +91,8 @@ const SELECTORS_MACOS = {
   CONTEXT_MENU: "~Context Menu",
   CONTEXT_MENU_BLOCK: "~friends-block",
   CONTEXT_MENU_CHAT: "~friends-chat",
-  CONTEXT_MENU_COPY_DID_KEY:
-    '-ios class chain:**/XCUIElementTypeButton[`label == "copy-id-context"`][2]',
-  CONTEXT_MENU_COPY_ID:
-    '-ios class chain:**/XCUIElementTypeButton[`label == "copy-id-context"`][1]',
+  CONTEXT_MENU_COPY_DID_KEY: "-ios class chain:**/XCUIElementTypeButton[2]",
+  CONTEXT_MENU_COPY_ID: "-ios class chain:**/XCUIElementTypeButton[1]",
   CONTEXT_MENU_FAVORITES_ADD: "~favorites-add",
   CONTEXT_MENU_FAVORITES_REMOVE: "~favorites-remove",
   CONTEXT_MENU_INCOMING_ACCEPT: "~friends-accept",

--- a/tests/screenobjects/settings/SettingsProfileScreen.ts
+++ b/tests/screenobjects/settings/SettingsProfileScreen.ts
@@ -24,8 +24,8 @@ const SELECTORS_WINDOWS = {
   CLEAR_AVATAR_BUTTON: "[name='clear-avatar']",
   CLEAR_BANNER_BUTTON: "[name='clear-banner']",
   CONTEXT_MENU: '[name="Context Menu"]',
-  CONTEXT_MENU_COPY_DID_KEY: '//Button[@Name="copy-id-context"][2]',
-  CONTEXT_MENU_COPY_ID: '//Button[@Name="copy-id-context"][1]',
+  CONTEXT_MENU_COPY_DID_KEY: "//Button[2]",
+  CONTEXT_MENU_COPY_ID: "//Button[1]",
   COPY_ID_BUTTON: '[name="copy-id-button"]',
   DISMISS_BUTTON: '[name="welcome-message-dismiss"]',
   INPUT_ERROR: '[name="input-error"]',
@@ -74,10 +74,8 @@ const SELECTORS_MACOS = {
   CLEAR_AVATAR_BUTTON: "clear-avatar",
   CLEAR_BANNER_BUTTON: "clear-banner",
   CONTEXT_MENU: "~Context Menu",
-  CONTEXT_MENU_COPY_DID_KEY:
-    '-ios class chain:**/XCUIElementTypeButton[`label == "copy-id-context"`][2]',
-  CONTEXT_MENU_COPY_ID:
-    '-ios class chain:**/XCUIElementTypeButton[`label == "copy-id-context"`][1]',
+  CONTEXT_MENU_COPY_DID_KEY: "-ios class chain:**/XCUIElementTypeButton[2]",
+  CONTEXT_MENU_COPY_ID: "-ios class chain:**/XCUIElementTypeButton[1]",
   COPY_ID_BUTTON: "~copy-id-button",
   DISMISS_BUTTON: "~welcome-message-dismiss",
   INPUT_ERROR: "~input-error",


### PR DESCRIPTION
### What this PR does 📖

- Removing aria label temporarily from copy id context menu. This will be updated again after PR from new aria labels on Uplink is complete and merged

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
