### PR TITLE
screenobject(update): update switch sliders validation methods

### DIFF
--- a/tests/screenobjects/UplinkMainScreen.ts
+++ b/tests/screenobjects/UplinkMainScreen.ts
@@ -345,18 +345,7 @@ export default class UplinkMainScreen extends AppScreen {
     } else {
       attributeToValidate = "Toggle.ToggleState";
     }
-    await browser.waitUntil(
-      async () => {
-        const updatedElement = await browser.$(element.selector);
-        const attributeValue =
-          await updatedElement.getAttribute(attributeToValidate);
-        return attributeValue === "1";
-      },
-      {
-        timeout: 5000,
-        timeoutMsg: "Switch was never enabled after 5 seconds",
-      },
-    );
+    await expect(element).toHaveAttribute(attributeToValidate, "1");
   }
 
   async validateToggleIsDisabled(element: WebdriverIO.Element) {
@@ -367,18 +356,7 @@ export default class UplinkMainScreen extends AppScreen {
     } else {
       attributeToValidate = "Toggle.ToggleState";
     }
-    await browser.waitUntil(
-      async () => {
-        const updatedElement = await browser.$(element.selector);
-        const attributeValue =
-          await updatedElement.getAttribute(attributeToValidate);
-        return attributeValue === "0";
-      },
-      {
-        timeout: 5000,
-        timeoutMsg: "Switch was never enabled after 5 seconds",
-      },
-    );
+    await expect(element).toHaveAttribute(attributeToValidate, "0");
   }
 
   async validateNoModalIsOpen() {

--- a/tests/screenobjects/UplinkMainScreen.ts
+++ b/tests/screenobjects/UplinkMainScreen.ts
@@ -345,9 +345,12 @@ export default class UplinkMainScreen extends AppScreen {
     } else {
       attributeToValidate = "Toggle.ToggleState";
     }
-    await driver.waitUntil(
+    await browser.waitUntil(
       async () => {
-        return (await element.getAttribute(attributeToValidate)) === "1";
+        const updatedElement = await browser.$(element.selector);
+        const attributeValue =
+          await updatedElement.getAttribute(attributeToValidate);
+        return attributeValue === "1";
       },
       {
         timeout: 5000,
@@ -364,9 +367,12 @@ export default class UplinkMainScreen extends AppScreen {
     } else {
       attributeToValidate = "Toggle.ToggleState";
     }
-    await driver.waitUntil(
+    await browser.waitUntil(
       async () => {
-        return (await element.getAttribute(attributeToValidate)) === "0";
+        const updatedElement = await browser.$(element.selector);
+        const attributeValue =
+          await updatedElement.getAttribute(attributeToValidate);
+        return attributeValue === "0";
       },
       {
         timeout: 5000,

--- a/tests/screenobjects/UplinkMainScreen.ts
+++ b/tests/screenobjects/UplinkMainScreen.ts
@@ -326,13 +326,53 @@ export default class UplinkMainScreen extends AppScreen {
 
   async getToggleState(element: WebdriverIO.Element) {
     const currentDriver = await this.getCurrentDriver();
-    let toggleState;
+    let toggleState: string;
+    let attributeToValidate: string;
     if (currentDriver === MACOS_DRIVER) {
-      toggleState = await element.getAttribute("value");
-    } else if (currentDriver === WINDOWS_DRIVER) {
-      toggleState = await element.getAttribute("Toggle.ToggleState");
+      attributeToValidate = "value";
+    } else {
+      attributeToValidate = "Toggle.ToggleState";
     }
+    toggleState = await element.getAttribute(attributeToValidate);
     return toggleState;
+  }
+
+  async validateToggleIsEnabled(element: WebdriverIO.Element) {
+    const currentDriver = await this.getCurrentDriver();
+    let attributeToValidate: string;
+    if (currentDriver === MACOS_DRIVER) {
+      attributeToValidate = "value";
+    } else {
+      attributeToValidate = "Toggle.ToggleState";
+    }
+    await driver.waitUntil(
+      async () => {
+        return (await element.getAttribute(attributeToValidate)) === "1";
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: "Switch was never enabled after 5 seconds",
+      },
+    );
+  }
+
+  async validateToggleIsDisabled(element: WebdriverIO.Element) {
+    const currentDriver = await this.getCurrentDriver();
+    let attributeToValidate: string;
+    if (currentDriver === MACOS_DRIVER) {
+      attributeToValidate = "value";
+    } else {
+      attributeToValidate = "Toggle.ToggleState";
+    }
+    await driver.waitUntil(
+      async () => {
+        return (await element.getAttribute(attributeToValidate)) === "0";
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: "Switch was never enabled after 5 seconds",
+      },
+    );
   }
 
   async validateNoModalIsOpen() {

--- a/tests/screenobjects/settings/SettingsAccessibilityScreen.ts
+++ b/tests/screenobjects/settings/SettingsAccessibilityScreen.ts
@@ -36,27 +36,37 @@ process.env.DRIVER === WINDOWS_DRIVER
 
 export default class SettingsAccessibilityScreen extends SettingsBaseScreen {
   constructor() {
-    super(SELECTORS.SETTINGS_AUDIO);
+    super(SELECTORS.SETTINGS_ACCESSIBILITY);
   }
 
   get openDyslexicCheckbox() {
-    return $(SELECTORS.SETTINGS_CONTROL).$(SELECTORS.SWITCH_SLIDER);
+    return this.openDyslexicSection
+      .$(SELECTORS.SETTINGS_CONTROL)
+      .$(SELECTORS.SWITCH_SLIDER);
   }
 
   get openDyslexicControllerValue() {
-    return $(SELECTORS.SETTINGS_CONTROL).$(SELECTORS.SETTINGS_CONTROL_CHECKBOX);
+    return this.openDyslexicSection
+      .$(SELECTORS.SETTINGS_CONTROL)
+      .$(SELECTORS.SETTINGS_CONTROL_CHECKBOX);
   }
 
   get openDyslexicDescription() {
-    return $(SELECTORS.OPEN_DYSLEXIC_SECTION)
+    return this.openDyslexicSection
+      .$(SELECTORS.OPEN_DYSLEXIC_SECTION)
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
   }
 
   get openDyslexicHeader() {
-    return $(SELECTORS.OPEN_DYSLEXIC_SECTION)
+    return this.openDyslexicSection
+      .$(SELECTORS.OPEN_DYSLEXIC_SECTION)
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_HEADER);
+  }
+
+  get openDyslexicSection() {
+    return this.settingsAccessibility.$(SELECTORS.OPEN_DYSLEXIC_SECTION);
   }
 
   get settingsAccessibility() {

--- a/tests/screenobjects/settings/SettingsAccessibilityScreen.ts
+++ b/tests/screenobjects/settings/SettingsAccessibilityScreen.ts
@@ -5,9 +5,7 @@ import SettingsBaseScreen from "@screenobjects/settings/SettingsBaseScreen";
 
 let SELECTORS = {};
 
-const SELECTORS_COMMON = {
-  SETTINGS_ACCESSIBILITY: "~settings-general",
-};
+const SELECTORS_COMMON = {};
 
 const SELECTORS_WINDOWS = {
   OPEN_DYSLEXIC_SECTION: '[name="open-dyslexic-section"]',
@@ -36,7 +34,7 @@ process.env.DRIVER === WINDOWS_DRIVER
 
 export default class SettingsAccessibilityScreen extends SettingsBaseScreen {
   constructor() {
-    super(SELECTORS.SETTINGS_ACCESSIBILITY);
+    super(SELECTORS.OPEN_DYSLEXIC_SECTION);
   }
 
   get openDyslexicCheckbox() {
@@ -53,24 +51,18 @@ export default class SettingsAccessibilityScreen extends SettingsBaseScreen {
 
   get openDyslexicDescription() {
     return this.openDyslexicSection
-      .$(SELECTORS.OPEN_DYSLEXIC_SECTION)
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
   }
 
   get openDyslexicHeader() {
     return this.openDyslexicSection
-      .$(SELECTORS.OPEN_DYSLEXIC_SECTION)
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_HEADER);
   }
 
   get openDyslexicSection() {
-    return this.settingsAccessibility.$(SELECTORS.OPEN_DYSLEXIC_SECTION);
-  }
-
-  get settingsAccessibility() {
-    return $(SELECTORS.SETTINGS_ACCESSIBILITY);
+    return $(SELECTORS.OPEN_DYSLEXIC_SECTION);
   }
 
   async clickOnOpenDyslexic() {

--- a/tests/screenobjects/settings/SettingsAccessibilityScreen.ts
+++ b/tests/screenobjects/settings/SettingsAccessibilityScreen.ts
@@ -72,4 +72,14 @@ export default class SettingsAccessibilityScreen extends SettingsBaseScreen {
       await clickOnSwitchMacOS(openDyslexicCheckbox);
     }
   }
+
+  async validateOpenDyslexicIsEnabled() {
+    const openDyslexicControllerValue = await this.openDyslexicControllerValue;
+    await this.validateToggleIsEnabled(openDyslexicControllerValue);
+  }
+
+  async validateOpenDyslexicIsDisabled() {
+    const openDyslexicControllerValue = await this.openDyslexicControllerValue;
+    await this.validateToggleIsDisabled(openDyslexicControllerValue);
+  }
 }

--- a/tests/screenobjects/settings/SettingsAudioScreen.ts
+++ b/tests/screenobjects/settings/SettingsAudioScreen.ts
@@ -327,4 +327,62 @@ export default class SettingsAudioScreen extends SettingsBaseScreen {
       await outputDeviceDropdown.addValue(device + "\uE007");
     }
   }
+
+  // Validate toggle methods enabled
+  async validateEchoCancellationIsEnabled() {
+    const echoCancellationControllerValue =
+      await this.echoCancellationControllerValue;
+    await this.validateToggleIsEnabled(echoCancellationControllerValue);
+  }
+
+  async validateInterfaceSoundsIsEnabled() {
+    const interfaceSoundsControllerValue =
+      await this.interfaceSoundsControllerValue;
+    await this.validateToggleIsEnabled(interfaceSoundsControllerValue);
+  }
+
+  async validateMediaSoundsIsEnabled() {
+    const mediaSoundsControllerValue = await this.mediaSoundsControllerValue;
+    await this.validateToggleIsEnabled(mediaSoundsControllerValue);
+  }
+
+  async validateMessageSoundsIsEnabled() {
+    const messageSoundsControllerValue =
+      await this.messageSoundsControllerValue;
+    await this.validateToggleIsEnabled(messageSoundsControllerValue);
+  }
+
+  async validateCallTimerIsEnabled() {
+    const callTimerControllerValue = await this.callTimerControllerValue;
+    await this.validateToggleIsEnabled(callTimerControllerValue);
+  }
+
+  // Validate toggle methods disabled
+  async validateEchoCancellationIsDisabled() {
+    const echoCancellationControllerValue =
+      await this.echoCancellationControllerValue;
+    await this.validateToggleIsDisabled(echoCancellationControllerValue);
+  }
+
+  async validateInterfaceSoundsIsDisabled() {
+    const interfaceSoundsControllerValue =
+      await this.interfaceSoundsControllerValue;
+    await this.validateToggleIsDisabled(interfaceSoundsControllerValue);
+  }
+
+  async validateMediaSoundsIsDisabled() {
+    const mediaSoundsControllerValue = await this.mediaSoundsControllerValue;
+    await this.validateToggleIsDisabled(mediaSoundsControllerValue);
+  }
+
+  async validateMessageSoundsIsDisabled() {
+    const messageSoundsControllerValue =
+      await this.messageSoundsControllerValue;
+    await this.validateToggleIsDisabled(messageSoundsControllerValue);
+  }
+
+  async validateCallTimerIsDisabled() {
+    const callTimerControllerValue = await this.callTimerControllerValue;
+    await this.validateToggleIsDisabled(callTimerControllerValue);
+  }
 }

--- a/tests/screenobjects/settings/SettingsDeveloperScreen.ts
+++ b/tests/screenobjects/settings/SettingsDeveloperScreen.ts
@@ -278,4 +278,40 @@ export default class SettingsDeveloperScreen extends SettingsBaseScreen {
       await driver.switchToWindow(uplinkWindow);
     }
   }
+
+  // Toggle Enabled Methods
+
+  async validateDeveloperModeIsEnabled() {
+    const developerModeToggle = await this.developerModeControllerValue;
+    await this.validateToggleIsEnabled(developerModeToggle);
+  }
+
+  async validateExperimentalFeaturesIsEnabled() {
+    const experimentalFeaturesToggle =
+      await this.experimentalFeaturesControllerValue;
+    await this.validateToggleIsEnabled(experimentalFeaturesToggle);
+  }
+
+  async validateSaveLogsIsEnabled() {
+    const saveLogsToggle = await this.saveLogsControllerValue;
+    await this.validateToggleIsEnabled(saveLogsToggle);
+  }
+
+  // Toggle Disabled Methods
+
+  async validateDeveloperModeIsDisabled() {
+    const developerModeToggle = await this.developerModeControllerValue;
+    await this.validateToggleIsDisabled(developerModeToggle);
+  }
+
+  async validateExperimentalFeaturesIsDisabled() {
+    const experimentalFeaturesToggle =
+      await this.experimentalFeaturesControllerValue;
+    await this.validateToggleIsDisabled(experimentalFeaturesToggle);
+  }
+
+  async validateSaveLogsIsDisabled() {
+    const saveLogsToggle = await this.saveLogsControllerValue;
+    await this.validateToggleIsDisabled(saveLogsToggle);
+  }
 }

--- a/tests/screenobjects/settings/SettingsExtensionsScreen.ts
+++ b/tests/screenobjects/settings/SettingsExtensionsScreen.ts
@@ -243,4 +243,26 @@ export default class SettingsExtensionsScreen extends SettingsBaseScreen {
     }
     return result.toString();
   }
+
+  async validateEmojiSelectorIsEnabled() {
+    const emojiSelectorCheckboxValue = await this.emojiSelectorCheckboxValue;
+    await this.validateToggleIsEnabled(emojiSelectorCheckboxValue);
+  }
+
+  async validateEnableAutomaticallyIsEnabled() {
+    const enableAutomaticallyControllerValue =
+      await this.enableAutomaticallyControllerValue;
+    await this.validateToggleIsEnabled(enableAutomaticallyControllerValue);
+  }
+
+  async validateEmojiSelectorIsDisabled() {
+    const emojiSelectorCheckboxValue = await this.emojiSelectorCheckboxValue;
+    await this.validateToggleIsDisabled(emojiSelectorCheckboxValue);
+  }
+
+  async validateEnableAutomaticallyIsDisabled() {
+    const enableAutomaticallyControllerValue =
+      await this.enableAutomaticallyControllerValue;
+    await this.validateToggleIsDisabled(enableAutomaticallyControllerValue);
+  }
 }

--- a/tests/screenobjects/settings/SettingsMessagesScreen.ts
+++ b/tests/screenobjects/settings/SettingsMessagesScreen.ts
@@ -115,4 +115,26 @@ export default class SettingsMessagesScreen extends SettingsBaseScreen {
     const settingsMessages = await this.settingsMessages;
     await settingsMessages.waitForExist();
   }
+
+  // Validate toggle enabled methods
+  async validateConvertEmojiIsEnabled() {
+    const convertEmojiToggle = await this.convertEmojiControllerValue;
+    await this.validateToggleIsEnabled(convertEmojiToggle);
+  }
+
+  async validateMarkdownSupportIsEnabled() {
+    const markdownSupportToggle = await this.markdownSupportControllerValue;
+    await this.validateToggleIsEnabled(markdownSupportToggle);
+  }
+
+  // Validate toggle disabled methods
+  async validateConvertEmojiIsDisabled() {
+    const convertEmojiToggle = await this.convertEmojiControllerValue;
+    await this.validateToggleIsDisabled(convertEmojiToggle);
+  }
+
+  async validateMarkdownSupportIsDisabled() {
+    const markdownSupportToggle = await this.markdownSupportControllerValue;
+    await this.validateToggleIsDisabled(markdownSupportToggle);
+  }
 }

--- a/tests/screenobjects/settings/SettingsNotificationsScreen.ts
+++ b/tests/screenobjects/settings/SettingsNotificationsScreen.ts
@@ -196,4 +196,56 @@ export default class SettingsNotificationsScreen extends SettingsBaseScreen {
     const settingsNotifications = await this.settingsNotifications;
     await settingsNotifications.waitForExist();
   }
+
+  // Toggle Enable Methods
+
+  async validateEnabledNotificationsIsEnabled() {
+    const enabledNotificationsControllerValue =
+      await this.enabledNotificationsControllerValue;
+    await this.validateToggleIsEnabled(enabledNotificationsControllerValue);
+  }
+
+  async validateFriendsNotificationsIsEnabled() {
+    const friendsNotificationsControllerValue =
+      await this.friendsNotificationsControllerValue;
+    await this.validateToggleIsEnabled(friendsNotificationsControllerValue);
+  }
+
+  async validateMessagesNotificationsIsEnabled() {
+    const messagesNotificationsControllerValue =
+      await this.messagesNotificationsControllerValue;
+    await this.validateToggleIsEnabled(messagesNotificationsControllerValue);
+  }
+
+  async validateSettingsNotificationsIsEnabled() {
+    const settingsNotificationsControllerValue =
+      await this.settingsNotificationsControllerValue;
+    await this.validateToggleIsEnabled(settingsNotificationsControllerValue);
+  }
+
+  // Toggle Disabled Methods
+
+  async validateEnabledNotificationsIsDisabled() {
+    const enabledNotificationsControllerValue =
+      await this.enabledNotificationsControllerValue;
+    await this.validateToggleIsDisabled(enabledNotificationsControllerValue);
+  }
+
+  async validateFriendsNotificationsIsDisabled() {
+    const friendsNotificationsControllerValue =
+      await this.friendsNotificationsControllerValue;
+    await this.validateToggleIsDisabled(friendsNotificationsControllerValue);
+  }
+
+  async validateMessagesNotificationsIsDisabled() {
+    const messagesNotificationsControllerValue =
+      await this.messagesNotificationsControllerValue;
+    await this.validateToggleIsDisabled(messagesNotificationsControllerValue);
+  }
+
+  async validateSettingsNotificationsIsDisabled() {
+    const settingsNotificationsControllerValue =
+      await this.settingsNotificationsControllerValue;
+    await this.validateToggleIsDisabled(settingsNotificationsControllerValue);
+  }
 }

--- a/tests/screenobjects/settings/SettingsNotificationsScreen.ts
+++ b/tests/screenobjects/settings/SettingsNotificationsScreen.ts
@@ -46,99 +46,115 @@ export default class SettingsNotificationsScreen extends SettingsBaseScreen {
   }
 
   get enabledNotificationsCheckbox() {
-    return $(SELECTORS.ENABLED_NOTIFICATIONS_SECTION).$(
-      SELECTORS.SWITCH_SLIDER,
-    );
+    return this.enabledNotificationsSection.$(SELECTORS.SWITCH_SLIDER);
   }
 
   get enabledNotificationsControllerValue() {
-    return $(SELECTORS.ENABLED_NOTIFICATIONS_SECTION).$(
+    return this.enabledNotificationsSection.$(
       SELECTORS.SETTINGS_CONTROL_CHECKBOX,
     );
   }
 
   get enabledNotificationsDescription() {
-    return $(SELECTORS.ENABLED_NOTIFICATIONS_SECTION)
+    return this.enabledNotificationsSection
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
   }
 
   get enabledNotificationsHeader() {
-    return $(SELECTORS.ENABLED_NOTIFICATIONS_SECTION)
+    return this.enabledNotificationsSection
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_HEADER);
   }
 
-  get friendsNotificationsCheckbox() {
-    return $(SELECTORS.FRIENDS_NOTIFICATIONS_SECTION).$(
-      SELECTORS.SWITCH_SLIDER,
+  get enabledNotificationsSection() {
+    return this.settingsNotifications.$(
+      SELECTORS.ENABLED_NOTIFICATIONS_SECTION,
     );
   }
 
+  get friendsNotificationsCheckbox() {
+    return this.friendsNotificationsSection.$(SELECTORS.SWITCH_SLIDER);
+  }
+
   get friendsNotificationsControllerValue() {
-    return $(SELECTORS.FRIENDS_NOTIFICATIONS_SECTION).$(
+    return this.friendsNotificationsSection.$(
       SELECTORS.SETTINGS_CONTROL_CHECKBOX,
     );
   }
 
   get friendsNotificationsDescription() {
-    return $(SELECTORS.FRIENDS_NOTIFICATIONS_SECTION)
+    return this.friendsNotificationsSection
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
   }
 
   get friendsNotificationsHeader() {
-    return $(SELECTORS.FRIENDS_NOTIFICATIONS_SECTION)
+    return this.friendsNotificationsSection
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_HEADER);
   }
 
-  get messagesNotificationsCheckbox() {
-    return $(SELECTORS.MESSAGES_NOTIFICATIONS_SECTION).$(
-      SELECTORS.SWITCH_SLIDER,
+  get friendsNotificationsSection() {
+    return this.settingsNotifications.$(
+      SELECTORS.FRIENDS_NOTIFICATIONS_SECTION,
     );
   }
 
+  get messagesNotificationsCheckbox() {
+    return this.messagesNotificationsSection.$(SELECTORS.SWITCH_SLIDER);
+  }
+
   get messagesNotificationsControllerValue() {
-    return $(SELECTORS.MESSAGES_NOTIFICATIONS_SECTION).$(
+    return this.messagesNotificationsSection.$(
       SELECTORS.SETTINGS_CONTROL_CHECKBOX,
     );
   }
 
   get messagesNotificationsDescription() {
-    return $(SELECTORS.MESSAGES_NOTIFICATIONS_SECTION)
+    return this.messagesNotificationsSection
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
   }
 
   get messagesNotificationsHeader() {
-    return $(SELECTORS.MESSAGES_NOTIFICATIONS_SECTION)
+    return this.messagesNotificationsSection
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_HEADER);
   }
 
-  get settingsNotificationsCheckbox() {
-    return $(SELECTORS.SETTINGS_NOTIFICATIONS_SECTION).$(
-      SELECTORS.SWITCH_SLIDER,
+  get messagesNotificationsSection() {
+    return this.settingsNotifications.$(
+      SELECTORS.MESSAGES_NOTIFICATIONS_SECTION,
     );
   }
 
+  get settingsNotificationsCheckbox() {
+    return this.settingsNotificationsSection.$(SELECTORS.SWITCH_SLIDER);
+  }
+
   get settingsNotificationsControllerValue() {
-    return $(SELECTORS.SETTINGS_NOTIFICATIONS_SECTION).$(
+    return this.settingsNotificationsSection.$(
       SELECTORS.SETTINGS_CONTROL_CHECKBOX,
     );
   }
 
   get settingsNotificationsDescription() {
-    return $(SELECTORS.SETTINGS_NOTIFICATIONS_SECTION)
+    return this.settingsNotificationsSection
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_DESCRIPTION);
   }
 
   get settingsNotificationsHeader() {
-    return $(SELECTORS.SETTINGS_NOTIFICATIONS_SECTION)
+    return this.settingsNotificationsSection
       .$(SELECTORS.SETTINGS_INFO)
       .$(SELECTORS.SETTINGS_INFO_HEADER);
+  }
+
+  get settingsNotificationsSection() {
+    return this.settingsNotifications.$(
+      SELECTORS.SETTINGS_NOTIFICATIONS_SECTION,
+    );
   }
 
   get settingsNotifications() {

--- a/tests/specs/07-settings-audio.spec.ts
+++ b/tests/specs/07-settings-audio.spec.ts
@@ -88,78 +88,44 @@ export default async function settingsAudioTests() {
   it("Settings Audio - Click on slider switches to enable the options", async () => {
     // Click on the switch slider from Settings Sounds & Audio Screen - Echo Cancellation
     await settingsAudio.clickOnEchoCancellation();
-
-    // Validate status changed to Enabled for switch
-    const toggleElementEcho = await settingsAudio.messageSoundsControllerValue;
-    await settingsAudio.validateToggleIsEnabled(toggleElementEcho);
+    await settingsAudio.validateEchoCancellationIsEnabled();
 
     // Click on the switch slider from Settings Sounds & Audio Screen - Interface Sounds
     await settingsAudio.clickOnInterfaceSounds();
-
-    // Validate status changed to Enabled for switch
-    const toggleElementInterface =
-      await settingsAudio.interfaceSoundsControllerValue;
-    await settingsAudio.validateToggleIsEnabled(toggleElementInterface);
+    await settingsAudio.validateInterfaceSoundsIsEnabled();
 
     // Click on the switch slider from Settings Sounds & Audio Screen - Media Sounds
     await settingsAudio.clickOnMediaSounds();
-
-    // Validate status changed to Enabled for switch
-    const toggleElementMedia = await settingsAudio.mediaSoundsControllerValue;
-    await settingsAudio.validateToggleIsEnabled(toggleElementMedia);
+    await settingsAudio.validateMediaSoundsIsEnabled();
 
     // Click on the switch slider from Settings Sounds & Audio Screen - Message Sounds
     await settingsAudio.clickOnMessageSounds();
-
-    // Validate status changed to Enabled for switch
-    const toggleElementMessage =
-      await settingsAudio.messageSoundsControllerValue;
-    await settingsAudio.validateToggleIsEnabled(toggleElementMessage);
+    await settingsAudio.validateMessageSoundsIsEnabled();
 
     // Click on the switch slider from Settings Sounds & Audio Screen - Call Timer
     await settingsAudio.clickOnCallTimer();
-
-    // Validate status changed to Enabled for switch
-    const toggleElementTimer = await settingsAudio.messageSoundsControllerValue;
-    await settingsAudio.validateToggleIsEnabled(toggleElementTimer);
+    await settingsAudio.validateCallTimerIsEnabled();
   });
 
   it("Settings Audio - Click on slider switches to disable the options", async () => {
     // Click on the switch slider from Settings Sounds & Audio Screen - Echo Cancellation
     await settingsAudio.clickOnEchoCancellation();
-
-    // Validate status changed to Disabled for switch
-    const toggleElementEcho = await settingsAudio.messageSoundsControllerValue;
-    await settingsAudio.validateToggleIsDisabled(toggleElementEcho);
+    await settingsAudio.validateEchoCancellationIsDisabled();
 
     // Click on the switch slider from Settings Sounds & Audio Screen - Interface Sounds
     await settingsAudio.clickOnInterfaceSounds();
-
-    // Validate status changed to Disabled for switch
-    const toggleElementInterface =
-      await settingsAudio.interfaceSoundsControllerValue;
-    await settingsAudio.validateToggleIsDisabled(toggleElementInterface);
+    await settingsAudio.validateInterfaceSoundsIsDisabled();
 
     // Click on the switch slider from Settings Sounds & Audio Screen - Media Sounds
     await settingsAudio.clickOnMediaSounds();
-
-    // Validate status changed to Disabled for switch
-    const toggleElementMedia = await settingsAudio.mediaSoundsControllerValue;
-    await settingsAudio.validateToggleIsDisabled(toggleElementMedia);
+    await settingsAudio.validateMediaSoundsIsDisabled();
 
     // Click on the switch slider from Settings Sounds & Audio Screen - Message Sounds
     await settingsAudio.clickOnMessageSounds();
-
-    // Validate status changed to Disabled for switch
-    const toggleElementMessage =
-      await settingsAudio.messageSoundsControllerValue;
-    await settingsAudio.validateToggleIsDisabled(toggleElementMessage);
+    await settingsAudio.validateMessageSoundsIsDisabled();
 
     // Click on the switch slider from Settings Sounds & Audio Screen - Call Timer
     await settingsAudio.clickOnCallTimer();
-
-    // Validate status changed to Disabled for switch
-    const toggleElementTimer = await settingsAudio.messageSoundsControllerValue;
-    await settingsAudio.validateToggleIsDisabled(toggleElementTimer);
+    await settingsAudio.validateCallTimerIsDisabled();
   });
 }

--- a/tests/specs/07-settings-audio.spec.ts
+++ b/tests/specs/07-settings-audio.spec.ts
@@ -86,80 +86,80 @@ export default async function settingsAudioTests() {
   });
 
   it("Settings Audio - Click on slider switches to enable the options", async () => {
-    // Click on the five switch sliders from the Settings Sounds & Audio Screen
+    // Click on the switch slider from Settings Sounds & Audio Screen - Echo Cancellation
     await settingsAudio.clickOnEchoCancellation();
-    await settingsAudio.clickOnInterfaceSounds();
-    await settingsAudio.clickOnMediaSounds();
-    await settingsAudio.clickOnMessageSounds();
-    await settingsAudio.clickOnCallTimer();
 
-    // Validate that all toggles have now value = "1" (enabled)
+    // Validate status changed to Enabled for switch
     const toggleElementEcho = await settingsAudio.messageSoundsControllerValue;
-    const echoCancellationStatus =
-      await settingsAudio.getToggleState(toggleElementEcho);
+    await settingsAudio.validateToggleIsEnabled(toggleElementEcho);
 
+    // Click on the switch slider from Settings Sounds & Audio Screen - Interface Sounds
+    await settingsAudio.clickOnInterfaceSounds();
+
+    // Validate status changed to Enabled for switch
     const toggleElementInterface =
       await settingsAudio.interfaceSoundsControllerValue;
-    const interfaceSoundsStatus = await settingsAudio.getToggleState(
-      toggleElementInterface,
-    );
+    await settingsAudio.validateToggleIsEnabled(toggleElementInterface);
 
+    // Click on the switch slider from Settings Sounds & Audio Screen - Media Sounds
+    await settingsAudio.clickOnMediaSounds();
+
+    // Validate status changed to Enabled for switch
     const toggleElementMedia = await settingsAudio.mediaSoundsControllerValue;
-    const mediaSoundsStatus =
-      await settingsAudio.getToggleState(toggleElementMedia);
+    await settingsAudio.validateToggleIsEnabled(toggleElementMedia);
 
+    // Click on the switch slider from Settings Sounds & Audio Screen - Message Sounds
+    await settingsAudio.clickOnMessageSounds();
+
+    // Validate status changed to Enabled for switch
     const toggleElementMessage =
       await settingsAudio.messageSoundsControllerValue;
-    const messageSoundsStatus =
-      await settingsAudio.getToggleState(toggleElementMessage);
+    await settingsAudio.validateToggleIsEnabled(toggleElementMessage);
 
+    // Click on the switch slider from Settings Sounds & Audio Screen - Call Timer
+    await settingsAudio.clickOnCallTimer();
+
+    // Validate status changed to Enabled for switch
     const toggleElementTimer = await settingsAudio.messageSoundsControllerValue;
-    const callTimerStatus =
-      await settingsAudio.getToggleState(toggleElementTimer);
-
-    await expect(echoCancellationStatus).toEqual("1");
-    await expect(interfaceSoundsStatus).toEqual("1");
-    await expect(mediaSoundsStatus).toEqual("1");
-    await expect(messageSoundsStatus).toEqual("1");
-    await expect(callTimerStatus).toEqual("1");
+    await settingsAudio.validateToggleIsEnabled(toggleElementTimer);
   });
 
   it("Settings Audio - Click on slider switches to disable the options", async () => {
-    // Click again on the four switch sliders from the Settings Sounds & Audio Screen
+    // Click on the switch slider from Settings Sounds & Audio Screen - Echo Cancellation
     await settingsAudio.clickOnEchoCancellation();
-    await settingsAudio.clickOnInterfaceSounds();
-    await settingsAudio.clickOnMediaSounds();
-    await settingsAudio.clickOnMessageSounds();
-    await settingsAudio.clickOnCallTimer();
 
-    // Validate that all toggles have now value = "0" (disabled)
+    // Validate status changed to Disabled for switch
     const toggleElementEcho = await settingsAudio.messageSoundsControllerValue;
-    const echoCancellationStatus =
-      await settingsAudio.getToggleState(toggleElementEcho);
+    await settingsAudio.validateToggleIsDisabled(toggleElementEcho);
 
+    // Click on the switch slider from Settings Sounds & Audio Screen - Interface Sounds
+    await settingsAudio.clickOnInterfaceSounds();
+
+    // Validate status changed to Disabled for switch
     const toggleElementInterface =
       await settingsAudio.interfaceSoundsControllerValue;
-    const interfaceSoundsStatus = await settingsAudio.getToggleState(
-      toggleElementInterface,
-    );
+    await settingsAudio.validateToggleIsDisabled(toggleElementInterface);
 
+    // Click on the switch slider from Settings Sounds & Audio Screen - Media Sounds
+    await settingsAudio.clickOnMediaSounds();
+
+    // Validate status changed to Disabled for switch
     const toggleElementMedia = await settingsAudio.mediaSoundsControllerValue;
-    const mediaSoundsStatus =
-      await settingsAudio.getToggleState(toggleElementMedia);
+    await settingsAudio.validateToggleIsDisabled(toggleElementMedia);
 
+    // Click on the switch slider from Settings Sounds & Audio Screen - Message Sounds
+    await settingsAudio.clickOnMessageSounds();
+
+    // Validate status changed to Disabled for switch
     const toggleElementMessage =
       await settingsAudio.messageSoundsControllerValue;
-    const messageSoundsStatus =
-      await settingsAudio.getToggleState(toggleElementMessage);
+    await settingsAudio.validateToggleIsDisabled(toggleElementMessage);
 
+    // Click on the switch slider from Settings Sounds & Audio Screen - Call Timer
+    await settingsAudio.clickOnCallTimer();
+
+    // Validate status changed to Disabled for switch
     const toggleElementTimer = await settingsAudio.messageSoundsControllerValue;
-    const callTimerStatus =
-      await settingsAudio.getToggleState(toggleElementTimer);
-
-    await expect(echoCancellationStatus).toEqual("0");
-    await expect(interfaceSoundsStatus).toEqual("0");
-    await expect(mediaSoundsStatus).toEqual("0");
-    await expect(messageSoundsStatus).toEqual("0");
-    await expect(callTimerStatus).toEqual("0");
+    await settingsAudio.validateToggleIsDisabled(toggleElementTimer);
   });
 }

--- a/tests/specs/08-settings-extensions.spec.ts
+++ b/tests/specs/08-settings-extensions.spec.ts
@@ -23,11 +23,11 @@ export default async function settingsExtensionsTests() {
     const emojiSelectorDescription =
       await settingsExtensions.emojiSelectorDescription;
 
-    await expect(emojiSelectorTitle).toHaveTextContaining("Emoji Selector");
-    await expect(emojiSelectorDeveloper).toHaveTextContaining(
+    await expect(emojiSelectorTitle).toHaveText("Emoji Selector");
+    await expect(emojiSelectorDeveloper).toHaveText(
       "SATELLITE <DEVS@SATELLITE.IM>",
     );
-    await expect(emojiSelectorDescription).toHaveTextContaining(
+    await expect(emojiSelectorDescription).toHaveText(
       "Browse the standard unicode library of emoji's and send them to friends.",
     );
   });
@@ -37,10 +37,7 @@ export default async function settingsExtensionsTests() {
     await settingsExtensions.clickOnEmojiSelectorCheckbox();
 
     // Validate that switch from Emoji Selector now has value = '0' (disabled)
-    const toggleElement = await settingsExtensions.emojiSelectorCheckboxValue;
-    const emojiSelectorState =
-      await settingsExtensions.getToggleState(toggleElement);
-    await expect(emojiSelectorState).toEqual("0");
+    await settingsExtensions.validateEmojiSelectorIsDisabled();
   });
 
   it("Settings Extensions - Enable Emoji Selector extension", async () => {
@@ -48,10 +45,7 @@ export default async function settingsExtensionsTests() {
     await settingsExtensions.clickOnEmojiSelectorCheckbox();
 
     // Validate that switch from Emoji Selector now has value = '1' (active)
-    const toggleElement = await settingsExtensions.emojiSelectorCheckboxValue;
-    const emojiSelectorState =
-      await settingsExtensions.getToggleState(toggleElement);
-    await expect(emojiSelectorState).toEqual("1");
+    await settingsExtensions.validateEmojiSelectorIsEnabled();
   });
 
   it("Settings Extensions - Go to Explore panel and assert contents", async () => {
@@ -60,15 +54,13 @@ export default async function settingsExtensionsTests() {
 
     // Validate warning message, search extensions header and input are displayed
     const installedAlertText = await settingsExtensions.installedAlertText;
-    await expect(installedAlertText).toHaveTextContaining(
+    await expect(installedAlertText).toHaveText(
       "Extensions are pre-compiled on external hardware. For added security you can compile extensions from source and place in the `extensions` folder.",
     );
 
     const extensionsSearchHeader =
       await settingsExtensions.extensionsSearchHeader;
-    await expect(extensionsSearchHeader).toHaveTextContaining(
-      "SEARCH EXTENSIONS",
-    );
+    await expect(extensionsSearchHeader).toHaveText("SEARCH EXTENSIONS");
 
     await settingsExtensions.extensionsSearchInput.waitForExist();
     const placeholder =
@@ -83,25 +75,21 @@ export default async function settingsExtensionsTests() {
     // Assert contents from screen
     const openExtensionsHeader =
       await settingsExtensions.openExtensionsHeaderText;
-    await expect(openExtensionsHeader).toHaveTextContaining(
-      "OPEN EXTENSIONS FOLDER",
-    );
+    await expect(openExtensionsHeader).toHaveText("OPEN EXTENSIONS FOLDER");
 
     const openExtensionsDescription =
       await settingsExtensions.openExtensionsDescriptionText;
-    await expect(openExtensionsDescription).toHaveTextContaining(
+    await expect(openExtensionsDescription).toHaveText(
       "Open the local directory containing your installed extensions.",
     );
 
     const enableAutomaticallyHeader =
       await settingsExtensions.enableAutomaticallyHeader;
-    await expect(enableAutomaticallyHeader).toHaveTextContaining(
-      "ENABLE AUTOMATICALLY",
-    );
+    await expect(enableAutomaticallyHeader).toHaveText("ENABLE AUTOMATICALLY");
 
     const enableAutomaticallyDescription =
       await settingsExtensions.enableAutomaticallyDescription;
-    await expect(enableAutomaticallyDescription).toHaveTextContaining(
+    await expect(enableAutomaticallyDescription).toHaveText(
       "When turned on, new extensions will automatically be enabled by default.",
     );
   });
@@ -111,12 +99,7 @@ export default async function settingsExtensionsTests() {
     await settingsExtensions.clickOnEnableAutomatically();
 
     // Validate that switch from Enable Automatically now has value = '1' (active)
-    const toggleElement =
-      await settingsExtensions.enableAutomaticallyControllerValue;
-    const enableAutomaticallyState =
-      await settingsExtensions.getToggleState(toggleElement);
-
-    await expect(enableAutomaticallyState).toEqual("1");
+    await settingsExtensions.validateEnableAutomaticallyIsEnabled();
   });
 
   it("Settings Extensions - Deactivate the switch slider for Enable Automatically", async () => {
@@ -124,12 +107,7 @@ export default async function settingsExtensionsTests() {
     await settingsExtensions.clickOnEnableAutomatically();
 
     // Validate that switch from Enable Automatically now has value = '0' (disabled)
-    const toggleElement =
-      await settingsExtensions.enableAutomaticallyControllerValue;
-    const enableAutomaticallyState =
-      await settingsExtensions.getToggleState(toggleElement);
-
-    await expect(enableAutomaticallyState).toEqual("0");
+    await settingsExtensions.validateEnableAutomaticallyIsDisabled();
   });
 
   // Skipped since it needs research on how to close external window from Explorer before proceeding with next tests

--- a/tests/specs/09-settings-notifications.spec.ts
+++ b/tests/specs/09-settings-notifications.spec.ts
@@ -53,171 +53,96 @@ export default async function settingsNotificationsTests() {
   it("Settings Notifications - Disable all notifications by switching ENABLED toggle to off", async () => {
     // Click on ENABLED switch slider to activate toggles and then validate that toggle has now value = "0" (disabled)
     await settingsNotifications.clickOnEnabledNotifications();
-    const enabledToggle =
-      await settingsNotifications.enabledNotificationsControllerValue;
-    const enabledState =
-      await settingsNotifications.getToggleState(enabledToggle);
-    await expect(enabledState).toEqual("0");
+    await settingsNotifications.validateEnabledNotificationsIsDisabled();
 
     // Validate that toggle switch for FRIENDS has now value = "0" (disabled)
-    const friendsToggle =
-      await settingsNotifications.friendsNotificationsControllerValue;
-    const friendsState =
-      await settingsNotifications.getToggleState(friendsToggle);
-    await expect(friendsState).toEqual("0");
+    await settingsNotifications.validateFriendsNotificationsIsDisabled();
 
     // Validate that toggle switch for MESSAGES has now value = "0" (disabled)
-    const messagesToggle =
-      await settingsNotifications.messagesNotificationsControllerValue;
-    const messagesState =
-      await settingsNotifications.getToggleState(messagesToggle);
-    await expect(messagesState).toEqual("0");
+    await settingsNotifications.validateMessagesNotificationsIsDisabled();
 
     // Validate that toggle switch for SETTINGS has now value = "0" (disabled)
-    const settingsToggle =
-      await settingsNotifications.settingsNotificationsControllerValue;
-    const settingsState =
-      await settingsNotifications.getToggleState(settingsToggle);
-    await expect(settingsState).toEqual("0");
+    await settingsNotifications.validateSettingsNotificationsIsDisabled();
   });
 
   it("Settings Notifications - Enable again all notifications by switching ENABLED toggle to on", async () => {
     // Click on ENABLED switch slider to activate toggles and then validate that toggle has now value = "1" (enabled)
     await settingsNotifications.clickOnEnabledNotifications();
-    const enabledToggle =
-      await settingsNotifications.enabledNotificationsControllerValue;
-    const enabledState =
-      await settingsNotifications.getToggleState(enabledToggle);
-    await expect(enabledState).toEqual("1");
+    await settingsNotifications.validateEnabledNotificationsIsEnabled();
 
     // Validate that toggle switch for FRIENDS has now value = "1" (enabled)
-    const friendsToggle =
-      await settingsNotifications.friendsNotificationsControllerValue;
-    const friendsState =
-      await settingsNotifications.getToggleState(friendsToggle);
-    await expect(friendsState).toEqual("1");
+    await settingsNotifications.validateFriendsNotificationsIsEnabled();
 
     // Validate that toggle switch for MESSAGES has now value = "1" (enabled)
-    const messagesToggle =
-      await settingsNotifications.messagesNotificationsControllerValue;
-    const messagesState =
-      await settingsNotifications.getToggleState(messagesToggle);
-    await expect(messagesState).toEqual("1");
+    await settingsNotifications.validateMessagesNotificationsIsEnabled();
 
     // Validate that toggle switch for SETTINGS has now value = "1" (enabled)
-    const settingsToggle =
-      await settingsNotifications.settingsNotificationsControllerValue;
-    const settingsState =
-      await settingsNotifications.getToggleState(settingsToggle);
-    await expect(settingsState).toEqual("0");
+    await settingsNotifications.validateSettingsNotificationsIsEnabled();
   });
 
   it("Settings Notifications - Enable only FRIENDS notifications", async () => {
     // Deactivate toggle switches for FRIENDS and MESSAGES initially
     await settingsNotifications.clickOnFriendsNotifications();
+    await settingsNotifications.validateFriendsNotificationsIsDisabled();
+
     await settingsNotifications.clickOnMessagesNotifications();
+    await settingsNotifications.validateMessagesNotificationsIsDisabled();
 
     // Click again on FRIENDS Notifications to activate this toggle
     await settingsNotifications.clickOnFriendsNotifications();
 
     // Validate that toggle switch for ENABLED has now value = "1" (enabled)
-    const enabledToggle =
-      await settingsNotifications.enabledNotificationsControllerValue;
-    const enabledState =
-      await settingsNotifications.getToggleState(enabledToggle);
-    await expect(enabledState).toEqual("1");
+    await settingsNotifications.validateEnabledNotificationsIsEnabled();
 
     // Validate that toggle switch for FRIENDS has now value = 1" (enabled)
-    const friendsToggle =
-      await settingsNotifications.friendsNotificationsControllerValue;
-    const friendsState =
-      await settingsNotifications.getToggleState(friendsToggle);
-    await expect(friendsState).toEqual("1");
+    await settingsNotifications.validateFriendsNotificationsIsEnabled();
 
     // Validate that toggle switch for MESSAGES still has value = "0" (disabled)
-    const messagesToggle =
-      await settingsNotifications.messagesNotificationsControllerValue;
-    const messagesState =
-      await settingsNotifications.getToggleState(messagesToggle);
-    await expect(messagesState).toEqual("0");
+    await settingsNotifications.validateMessagesNotificationsIsDisabled();
 
     // Validate that toggle switch for SETTINGS still has value = "0" (disabled)
-    const settingsToggle =
-      await settingsNotifications.settingsNotificationsControllerValue;
-    const settingsState =
-      await settingsNotifications.getToggleState(settingsToggle);
-    await expect(settingsState).toEqual("0");
+    await settingsNotifications.validateSettingsNotificationsIsDisabled();
   });
 
   it("Settings Notifications - Enable only MESSAGES notifications", async () => {
     // Deactivate toggle switches for FRIENDS
     await settingsNotifications.clickOnFriendsNotifications();
+    await settingsNotifications.validateFriendsNotificationsIsDisabled();
 
     // Click on MESSAGES Notifications to activate this toggle
     await settingsNotifications.clickOnMessagesNotifications();
 
     // Validate that toggle switch for ENABLED still has value = "1" (enabled)
-    const enabledToggle =
-      await settingsNotifications.enabledNotificationsControllerValue;
-    const enabledState =
-      await settingsNotifications.getToggleState(enabledToggle);
-    await expect(enabledState).toEqual("1");
+    await settingsNotifications.validateEnabledNotificationsIsEnabled();
 
     // Validate that toggle switch for FRIENDS now has value = "0" (disabled)
-    const friendsToggle =
-      await settingsNotifications.friendsNotificationsControllerValue;
-    const friendsState =
-      await settingsNotifications.getToggleState(friendsToggle);
-    await expect(friendsState).toEqual("0");
+    await settingsNotifications.validateFriendsNotificationsIsDisabled();
 
     // Validate that toggle switch for MESSAGES has now value = 1" (enabled)
-    const messagesToggle =
-      await settingsNotifications.messagesNotificationsControllerValue;
-    const messagesState =
-      await settingsNotifications.getToggleState(messagesToggle);
-    await expect(messagesState).toEqual("1");
+    await settingsNotifications.validateMessagesNotificationsIsEnabled();
 
     // Validate that toggle switch for SETTINGS still has value = "0" (disabled)
-    const settingsToggle =
-      await settingsNotifications.settingsNotificationsControllerValue;
-    const settingsState =
-      await settingsNotifications.getToggleState(settingsToggle);
-    await expect(settingsState).toEqual("0");
+    await settingsNotifications.validateSettingsNotificationsIsDisabled();
   });
 
   it("Settings Notifications - Enable only SETTINGS notifications", async () => {
     // Deactivate toggle switches for MESSAGES
     await settingsNotifications.clickOnMessagesNotifications();
+    await settingsNotifications.validateMessagesNotificationsIsDisabled();
 
     // Click again on SETTINGS Notifications to activate this toggle
     await settingsNotifications.clickOnSettingsNotifications();
 
     // Validate that toggle switch for ENABLED still has value = "1" (enabled)
-    const enabledToggle =
-      await settingsNotifications.enabledNotificationsControllerValue;
-    const enabledState =
-      await settingsNotifications.getToggleState(enabledToggle);
-    await expect(enabledState).toEqual("1");
+    await settingsNotifications.validateEnabledNotificationsIsEnabled();
 
     // Validate that toggle switch for FRIENDS still has value = "0" (disabled)
-    const friendsToggle =
-      await settingsNotifications.friendsNotificationsControllerValue;
-    const friendsState =
-      await settingsNotifications.getToggleState(friendsToggle);
-    await expect(friendsState).toEqual("0");
+    await settingsNotifications.validateFriendsNotificationsIsDisabled();
 
     // Validate that toggle switch for MESSAGES still has value = "0" (disabled)
-    const messagesToggle =
-      await settingsNotifications.messagesNotificationsControllerValue;
-    const messagesState =
-      await settingsNotifications.getToggleState(messagesToggle);
-    await expect(messagesState).toEqual("0");
+    await settingsNotifications.validateMessagesNotificationsIsDisabled();
 
     // Validate that toggle switch for SETTINGS now has value = "1" (enabled)
-    const settingsToggle =
-      await settingsNotifications.settingsNotificationsControllerValue;
-    const settingsState =
-      await settingsNotifications.getToggleState(settingsToggle);
-    await expect(settingsState).toEqual("1");
+    await settingsNotifications.validateSettingsNotificationsIsEnabled();
   });
 }

--- a/tests/specs/09-settings-notifications.spec.ts
+++ b/tests/specs/09-settings-notifications.spec.ts
@@ -76,8 +76,8 @@ export default async function settingsNotificationsTests() {
     // Validate that toggle switch for MESSAGES has now value = "1" (enabled)
     await settingsNotifications.validateMessagesNotificationsIsEnabled();
 
-    // Validate that toggle switch for SETTINGS has now value = "1" (enabled)
-    await settingsNotifications.validateSettingsNotificationsIsEnabled();
+    // Validate that toggle switch for SETTINGS has now value = "0" (disabled)
+    await settingsNotifications.validateSettingsNotificationsIsDisabled();
   });
 
   it("Settings Notifications - Enable only FRIENDS notifications", async () => {

--- a/tests/specs/09-settings-notifications.spec.ts
+++ b/tests/specs/09-settings-notifications.spec.ts
@@ -83,10 +83,7 @@ export default async function settingsNotificationsTests() {
   it("Settings Notifications - Enable only FRIENDS notifications", async () => {
     // Deactivate toggle switches for FRIENDS and MESSAGES initially
     await settingsNotifications.clickOnFriendsNotifications();
-    await settingsNotifications.validateFriendsNotificationsIsDisabled();
-
     await settingsNotifications.clickOnMessagesNotifications();
-    await settingsNotifications.validateMessagesNotificationsIsDisabled();
 
     // Click again on FRIENDS Notifications to activate this toggle
     await settingsNotifications.clickOnFriendsNotifications();
@@ -107,7 +104,6 @@ export default async function settingsNotificationsTests() {
   it("Settings Notifications - Enable only MESSAGES notifications", async () => {
     // Deactivate toggle switches for FRIENDS
     await settingsNotifications.clickOnFriendsNotifications();
-    await settingsNotifications.validateFriendsNotificationsIsDisabled();
 
     // Click on MESSAGES Notifications to activate this toggle
     await settingsNotifications.clickOnMessagesNotifications();
@@ -128,7 +124,6 @@ export default async function settingsNotificationsTests() {
   it("Settings Notifications - Enable only SETTINGS notifications", async () => {
     // Deactivate toggle switches for MESSAGES
     await settingsNotifications.clickOnMessagesNotifications();
-    await settingsNotifications.validateMessagesNotificationsIsDisabled();
 
     // Click again on SETTINGS Notifications to activate this toggle
     await settingsNotifications.clickOnSettingsNotifications();

--- a/tests/specs/10-settings-accessibility.spec.ts
+++ b/tests/specs/10-settings-accessibility.spec.ts
@@ -33,12 +33,7 @@ export default async function settingsAccessibilityTests() {
     await settingsAccessibility.clickOnOpenDyslexic();
 
     // Validate that toggle has now value = "1" (enabled)
-    const toggleElement =
-      await settingsAccessibility.openDyslexicControllerValue;
-    const openDyslexicStatus =
-      await settingsAccessibility.getToggleState(toggleElement);
-
-    await expect(openDyslexicStatus).toEqual("1");
+    await settingsAccessibility.validateOpenDyslexicIsEnabled();
   });
 
   it("Settings Audio - Click on slider switches to disable the options", async () => {
@@ -46,11 +41,6 @@ export default async function settingsAccessibilityTests() {
     await settingsAccessibility.clickOnOpenDyslexic();
 
     // Validate that toggle has now value = "0" (disabled)
-    const toggleElement =
-      await settingsAccessibility.openDyslexicControllerValue;
-    const openDyslexicStatus =
-      await settingsAccessibility.getToggleState(toggleElement);
-
-    await expect(openDyslexicStatus).toEqual("0");
+    await settingsAccessibility.validateOpenDyslexicIsDisabled();
   });
 }

--- a/tests/specs/13-settings-developer.spec.ts
+++ b/tests/specs/13-settings-developer.spec.ts
@@ -23,10 +23,8 @@ export default async function settingsDeveloperTests() {
       await settingsDeveloper.experimentalFeaturesHeader;
     const experimentalDescription =
       await settingsDeveloper.experimentalFeaturesDescription;
-    await expect(experimentalHeader).toHaveTextContaining(
-      "EXPERIMENTAL FEATURES",
-    );
-    await expect(experimentalDescription).toHaveTextContaining(
+    await expect(experimentalHeader).toHaveText("EXPERIMENTAL FEATURES");
+    await expect(experimentalDescription).toHaveText(
       "Enables features which may be incomplete or non-functional.",
     );
 
@@ -34,8 +32,8 @@ export default async function settingsDeveloperTests() {
     const developerModeHeader = await settingsDeveloper.developerModeHeader;
     const developerModeDescription =
       await settingsDeveloper.developerModeDescription;
-    await expect(developerModeHeader).toHaveTextContaining("DEVELOPER MODE");
-    await expect(developerModeDescription).toHaveTextContaining(
+    await expect(developerModeHeader).toHaveText("DEVELOPER MODE");
+    await expect(developerModeDescription).toHaveText(
       "Enabling developer mode adds logging and displays helpful debug information on the UI.",
     );
 
@@ -44,18 +42,16 @@ export default async function settingsDeveloperTests() {
       await settingsDeveloper.testNotificationHeader;
     const testNotificationDescription =
       await settingsDeveloper.testNotificationDescription;
-    await expect(testNotificationHeader).toHaveTextContaining(
-      "TEST NOTIFICATION",
-    );
-    await expect(testNotificationDescription).toHaveTextContaining(
+    await expect(testNotificationHeader).toHaveText("TEST NOTIFICATION");
+    await expect(testNotificationDescription).toHaveText(
       "Sends a test notification",
     );
 
     // Validate OPEN CACHE section
     const openCacheHeader = await settingsDeveloper.openCacheHeader;
     const openCacheDescription = await settingsDeveloper.openCacheDescription;
-    await expect(openCacheHeader).toHaveTextContaining("OPEN CACHE");
-    await expect(openCacheDescription).toHaveTextContaining(
+    await expect(openCacheHeader).toHaveText("OPEN CACHE");
+    await expect(openCacheDescription).toHaveText(
       "Open the cache in your default file browser.",
     );
 
@@ -64,34 +60,34 @@ export default async function settingsDeveloperTests() {
       await settingsDeveloper.compressAndDownloadCacheHeader;
     const compressAndDownloadDescription =
       await settingsDeveloper.compressAndDownloadCacheDescription;
-    await expect(compressAndDownloadHeader).toHaveTextContaining(
+    await expect(compressAndDownloadHeader).toHaveText(
       "COMPRESS & DOWNLOAD CACHE",
     );
-    await expect(compressAndDownloadDescription).toHaveTextContaining(
+    await expect(compressAndDownloadDescription).toHaveText(
       "For debugging with other developers, you can compress your cache to zip and share it. Don't do this if this is a real account you use.",
     );
 
     // Validate PRINT STATE section
     const printStateHeader = await settingsDeveloper.printStateHeader;
     const printStateDescription = await settingsDeveloper.printStateDescription;
-    await expect(printStateHeader).toHaveTextContaining("PRINT STATE");
-    await expect(printStateDescription).toHaveTextContaining(
+    await expect(printStateHeader).toHaveText("PRINT STATE");
+    await expect(printStateDescription).toHaveText(
       "Display State in the debug logger",
     );
 
     // Validate CLEAR CACHE section
     const clearCacheHeader = await settingsDeveloper.clearCacheHeader;
     const clearCacheDescription = await settingsDeveloper.clearCacheDescription;
-    await expect(clearCacheHeader).toHaveTextContaining("CLEAR CACHE");
-    await expect(clearCacheDescription).toHaveTextContaining(
+    await expect(clearCacheHeader).toHaveText("CLEAR CACHE");
+    await expect(clearCacheDescription).toHaveText(
       "Reset your account, basically.",
     );
 
     // Validate SAVE LOGS IN A FILE section
     const saveLogsHeader = await settingsDeveloper.saveLogsHeader;
     const saveLogsDescription = await settingsDeveloper.saveLogsDescription;
-    await expect(saveLogsHeader).toHaveTextContaining("SAVE LOGS IN A FILE");
-    await expect(saveLogsDescription).toHaveTextContaining(
+    await expect(saveLogsHeader).toHaveText("SAVE LOGS IN A FILE");
+    await expect(saveLogsDescription).toHaveText(
       "Enabling this option, logs will be saved in a file and will be persistent.",
     );
   });

--- a/tests/specs/13-settings-developer.spec.ts
+++ b/tests/specs/13-settings-developer.spec.ts
@@ -72,7 +72,7 @@ export default async function settingsDeveloperTests() {
     const printStateDescription = await settingsDeveloper.printStateDescription;
     await expect(printStateHeader).toHaveText("PRINT STATE");
     await expect(printStateDescription).toHaveText(
-      "Display State in the debug logger",
+      "Display State in the debug logger.",
     );
 
     // Validate CLEAR CACHE section

--- a/tests/specs/13-settings-developer.spec.ts
+++ b/tests/specs/13-settings-developer.spec.ts
@@ -93,10 +93,7 @@ export default async function settingsDeveloperTests() {
     await settingsDeveloper.clickOnSaveLogs();
 
     // Validate that switch has now value = '1' (active)
-    const toggleElement = await settingsDeveloper.saveLogsControllerValue;
-    const saveLogsStatus =
-      await settingsDeveloper.getToggleState(toggleElement);
-    await expect(saveLogsStatus).toEqual("1");
+    await settingsDeveloper.validateSaveLogsIsEnabled();
   });
 
   // Skipped due to failure on app when disabling the switch the app crashes
@@ -105,10 +102,7 @@ export default async function settingsDeveloperTests() {
     await settingsDeveloper.clickOnSaveLogs();
 
     // Validate that switch has now value = '0' (disabled)
-    const toggleElement = await settingsDeveloper.saveLogsControllerValue;
-    const saveLogsStatus =
-      await settingsDeveloper.getToggleState(toggleElement);
-    await expect(saveLogsStatus).toEqual("0");
+    await settingsDeveloper.validateSaveLogsIsDisabled();
   });
 
   // Test skipped since it fails on Windows CI
@@ -117,10 +111,7 @@ export default async function settingsDeveloperTests() {
     await settingsDeveloper.clickOnDeveloperMode();
 
     // Validate that switch has now value = '1' (active)
-    const toggleElement = await settingsDeveloper.developerModeControllerValue;
-    const developerModeStatus =
-      await settingsDeveloper.getToggleState(toggleElement);
-    await expect(developerModeStatus).toEqual("1");
+    await settingsDeveloper.validateDeveloperModeIsEnabled();
   });
 
   // Test skipped since it fails on Windows CI
@@ -129,10 +120,7 @@ export default async function settingsDeveloperTests() {
     await settingsDeveloper.clickOnDeveloperMode();
 
     // Validate that switch has now value = '0' (disabled)
-    const toggleElement = await settingsDeveloper.developerModeControllerValue;
-    const developerModeStatus =
-      await settingsDeveloper.getToggleState(toggleElement);
-    await expect(developerModeStatus).toEqual("0");
+    await settingsDeveloper.validateDeveloperModeIsDisabled();
   });
 
   // Skipped because it needs the aria label fixed for test notifications button

--- a/tests/specs/13-settings-developer.spec.ts
+++ b/tests/specs/13-settings-developer.spec.ts
@@ -44,7 +44,7 @@ export default async function settingsDeveloperTests() {
       await settingsDeveloper.testNotificationDescription;
     await expect(testNotificationHeader).toHaveText("TEST NOTIFICATION");
     await expect(testNotificationDescription).toHaveText(
-      "Sends a test notification",
+      "Sends a test notification.",
     );
 
     // Validate OPEN CACHE section

--- a/tests/specs/15-settings-messages.spec.ts
+++ b/tests/specs/15-settings-messages.spec.ts
@@ -36,38 +36,20 @@ export default async function settingsMessagesTests() {
   it("Settings Messages - Disable both convert emoji and markdown support toggles", async () => {
     // Click on switch slider for Convert Emoji to disable option and then validate that toggle has now value = "0" (disabled)
     await settingsMessages.clickOnConvertEmoji();
-    const convertEmojiToggle =
-      await settingsMessages.convertEmojiControllerValue;
-    const convertEmojiState =
-      await settingsMessages.getToggleState(convertEmojiToggle);
-    await expect(convertEmojiState).toEqual("0");
+    await settingsMessages.validateConvertEmojiIsDisabled();
 
     // Click on switch slider for Markdown Support to disable option and then validate that toggle has now value = "0" (disabled)
     await settingsMessages.clickOnMarkdownSupport();
-    const markdownSupportToggle =
-      await settingsMessages.markdownSupportControllerValue;
-    const markdownSupportState = await settingsMessages.getToggleState(
-      markdownSupportToggle,
-    );
-    await expect(markdownSupportState).toEqual("0");
+    await settingsMessages.validateMarkdownSupportIsDisabled();
   });
 
   it("Settings Messages - Enable again both convert emoji and markdown support toggles", async () => {
     // Click on switch slider for Convert Emoji to enable option and then validate that toggle has now value = "1" (enabled)
     await settingsMessages.clickOnConvertEmoji();
-    const convertEmojiToggle =
-      await settingsMessages.convertEmojiControllerValue;
-    const convertEmojiState =
-      await settingsMessages.getToggleState(convertEmojiToggle);
-    await expect(convertEmojiState).toEqual("1");
+    await settingsMessages.validateConvertEmojiIsEnabled();
 
     // Click on switch slider for Markdown Support to enable option and then validate that toggle has now value = "1" (enabled)
     await settingsMessages.clickOnMarkdownSupport();
-    const markdownSupportToggle =
-      await settingsMessages.markdownSupportControllerValue;
-    const markdownSupportState = await settingsMessages.getToggleState(
-      markdownSupportToggle,
-    );
-    await expect(markdownSupportState).toEqual("1");
+    await settingsMessages.validateMarkdownSupportIsEnabled();
   });
 }


### PR DESCRIPTION
### What this PR does 📖

- Update Switch Sliders validation method to click on slider and then validate that it changes. I noticed that there is some flakiness on tests happening not often, when appium does the assertion of the change before the slider has changed, and then test fails apparently because the switch was not clicked, but at the end it was just a race condition happening

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
