### PR TITLE
chore(warp): replace default node under CI execution

### DIFF
--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -183,10 +183,8 @@ jobs:
       - name: Get localPeerId and build app 🖥️
         id: get_local_peer_id
         run: |
-          $localPeerId = Select-String -Path .\warp\peerID.txt -Pattern 'Local PeerID: ([^\s]*)' | ForEach-Object { $_.Matches.Groups[1].Value }
-          echo "localPeerId=$localPeerId" >> $env:GITHUB_ENV
-          $env:SHUTTLE_ADDR_POINT="/ip4/127.0.0.1/tcp/4444/p2p/" + $localPeerId
-          cargo build --release
+          ./appium-tests/scripts/replace_node.ps1
+          cargo build --release -F production_mode
 
       - name: Create ZIP archive on Windows 🗳️
         run: Compress-Archive -Path target/release/uplink.exe -Destination uplinkWindows.zip

--- a/config/wdio.mac.app.conf.ts
+++ b/config/wdio.mac.app.conf.ts
@@ -55,12 +55,7 @@ export const config: WebdriverIO.Config = {
         platformName: "mac",
         "appium:automationName": MACOS_DRIVER,
         "appium:bundleId": MACOS_BUNDLE_ID,
-        "appium:arguments": [
-          "--discovery",
-          "disable",
-          "--path",
-          homedir() + "/.uplink",
-        ],
+        "appium:arguments": ["--path", homedir() + "/.uplink"],
         "appium:systemPort": 4724,
         "appium:prerun": {
           command: 'do shell script "rm -rf ~/.uplink"',

--- a/config/wdio.mac.ci.conf.ts
+++ b/config/wdio.mac.ci.conf.ts
@@ -54,12 +54,7 @@ export const config: WebdriverIO.Config = {
         platformName: "mac",
         "appium:automationName": MACOS_DRIVER,
         "appium:bundleId": MACOS_BUNDLE_ID,
-        "appium:arguments": [
-          "--discovery",
-          "disable",
-          "--path",
-          homedir() + "/.uplink",
-        ],
+        "appium:arguments": ["--path", homedir() + "/.uplink"],
         "appium:systemPort": 4724,
         "appium:prerun": {
           command: 'do shell script "rm -rf ~/.uplink"',

--- a/config/wdio.mac.multiremote.conf.ts
+++ b/config/wdio.mac.multiremote.conf.ts
@@ -53,12 +53,7 @@ export const config: WebdriverIO.Config = {
         platformName: "mac",
         "appium:automationName": MACOS_DRIVER,
         "appium:bundleId": MACOS_USER_A_BUNDLE_ID,
-        "appium:arguments": [
-          "--discovery",
-          "disable",
-          "--path",
-          homedir() + "/.uplink",
-        ],
+        "appium:arguments": ["--path", homedir() + "/.uplink"],
         "appium:systemPort": 4725,
         "appium:prerun": {
           command:

--- a/config/wdio.windows.app.conf.ts
+++ b/config/wdio.windows.app.conf.ts
@@ -54,7 +54,6 @@ export const config: WebdriverIO.Config = {
         "appium:deviceName": "WindowsPC",
         "appium:automationName": "windows",
         "appium:app": WINDOWS_APP_LOCATION,
-        "appium:appArguments": "--discovery disable",
         "ms:waitForAppLaunch": 30,
         "appium:prerun": {
           command:

--- a/config/wdio.windows.ci.conf.ts
+++ b/config/wdio.windows.ci.conf.ts
@@ -54,7 +54,6 @@ export const config: WebdriverIO.Config = {
         "appium:deviceName": "WindowsPC",
         "appium:automationName": "windows",
         "appium:app": WINDOWS_APP_LOCATION,
-        "appium:appArguments": "--discovery disable",
         "ms:waitForAppLaunch": 50,
         "appium:prerun": {
           command:

--- a/config/wdio.windows.onetime.conf.ts
+++ b/config/wdio.windows.onetime.conf.ts
@@ -54,9 +54,7 @@ export const config: WebdriverIO.Config = {
         "appium:automationName": "windows",
         "appium:app": WINDOWS_APP_LOCATION,
         "appium:appArguments":
-          "--discovery disable --path " +
-          join(process.cwd(), "\\apps\\onetimescript2") +
-          " trace2",
+          "--path " + join(process.cwd(), "\\apps\\onetimescript2") + " trace2",
         "appium:prerun": {
           command:
             "If (Test-Path $home/.uplink/.user) {Remove-Item -Recurse -Force $home/.uplink/.user} Else { Break }",

--- a/scripts/replace_node.ps1
+++ b/scripts/replace_node.ps1
@@ -4,16 +4,6 @@
 $localPeerId = Select-String -Path .\warp\peerID.txt -Pattern 'Local PeerID: ([^\s]*)' | ForEach-Object { $_.Matches.Groups[1].Value }
 
 # Update the values in ./common/src/warp_runner/mod.rs and store in a temporary file
-(Get-Content .\common\src\warp_runner\mod.rs) -replace '/ip4/104.236.194.35/tcp/34053/p2p/12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu', '/ip4/127.0.0.1/tcp/4444/p2p/' + $localPeerId |
-    Set-Content -Path .\common\src\warp_runner\mod.rs
-
-
-# Contents of replace_node.ps1
-
-# Read the values from ./warp/peerID
-$localPeerId = Select-String -Path .\warp\peerID.txt -Pattern 'Local PeerID: ([^\s]*)' | ForEach-Object { $_.Matches.Groups[1].Value }
-
-# Update the values in ./common/src/warp_runner/mod.rs and store in a temporary file
 (Get-Content .\common\src\warp_runner\mod.rs) -replace '/ip4/104.236.194.35/tcp/34053/', '/ip4/127.0.0.1/tcp/4444/' `
                                                       -replace 'p2p/12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu', 'p2p/' + $localPeerId ` |
     Set-Content -Path .\common\src\warp_runner\mod.rs

--- a/scripts/replace_node.ps1
+++ b/scripts/replace_node.ps1
@@ -3,8 +3,7 @@
 # Read the values from ./warp/peerID
 $localPeerId = Select-String -Path .\warp\peerID.txt -Pattern 'Local PeerID: ([^\s]*)' | ForEach-Object { $_.Matches.Groups[1].Value }
 
-# Update the values in ./Makefile and store in a temporary file
-(Get-Content .\Makefile) -replace 'cargo build --release -F', 'SHUTTLE_ADDR_POINT=/ip4/127.0.0.1/tcp/4444/p2p/ cargo build --release -F' `
-                                                      -replace 'p2p/ ', 'p2p/ ' + $localPeerId ` |
-    Set-Content -Path .\Makefile
+# Update the values in ./common/src/warp_runner/mod.rs and store in a temporary file
+(Get-Content .\common\src\warp_runner\mod.rs) -replace '/ip4/104.236.194.35/tcp/34053/p2p/12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu', '/ip4/127.0.0.1/tcp/4444/p2p/' + $localPeerId |
+    Set-Content -Path .\common\src\warp_runner\mod.rs
 

--- a/scripts/replace_node.ps1
+++ b/scripts/replace_node.ps1
@@ -1,12 +1,23 @@
-# Contents of replace_node.ps1
+# Set the path to the mod.rs file
+$modRsFilePath = ".\common\src\warp_runner\mod.rs"
 
-# Read the values from ./warp/peerID
-$localPeerId = Select-String -Path .\warp\peerID.txt -Pattern 'Local PeerID: ([^\s]*)' | ForEach-Object { $_.Matches.Groups[1].Value }
+# Read the contents of the mod.rs file
+$modRsContent = Get-Content -Path $modRsFilePath -Raw
 
-# Update the values in ./common/src/warp_runner/mod.rs and store in a temporary file
-(Get-Content .\common\src\warp_runner\mod.rs) -replace '/ip4/104.236.194.35/tcp/34053/', '/ip4/127.0.0.1/tcp/4444/' `
-                                                      -replace 'p2p/12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu', 'p2p/' + $localPeerId ` |
-    Set-Content -Path .\common\src\warp_runner\mod.rs
+# Replace the old address with the new address in the mod.rs content
+$newModRsContentFirst = $modRsContent -replace "/ip4/104.236.194.35/tcp/34053/", "/ip4/127.0.0.1/tcp/4444/"
 
+# Set the new address based on the content of peerID.txt
+$peerIDFilePath = ".\warp\peerID.txt"
+$newPeerID = (Get-Content -Path $peerIDFilePath | Select-String -Pattern '/ip4/\d+\.\d+\.\d+\.\d+/tcp/\d+/p2p/(\S+)').Matches.Groups[1].Value
 
+# Define the old address to be replaced
+$oldPeerId = "12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu"
 
+# Replace the old address with the new address in the mod.rs content
+$newModRsContentTwo = $newModRsContentFirst -replace $oldPeerId, $newPeerID
+
+# Write the modified content back to the mod.rs file
+Set-Content -Path $modRsFilePath -Value $newModRsContentTwo
+
+Write-Host "Replacement complete for Local Peer ID."

--- a/scripts/replace_node.ps1
+++ b/scripts/replace_node.ps1
@@ -7,3 +7,16 @@ $localPeerId = Select-String -Path .\warp\peerID.txt -Pattern 'Local PeerID: ([^
 (Get-Content .\common\src\warp_runner\mod.rs) -replace '/ip4/104.236.194.35/tcp/34053/p2p/12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu', '/ip4/127.0.0.1/tcp/4444/p2p/' + $localPeerId |
     Set-Content -Path .\common\src\warp_runner\mod.rs
 
+
+# Contents of replace_node.ps1
+
+# Read the values from ./warp/peerID
+$localPeerId = Select-String -Path .\warp\peerID.txt -Pattern 'Local PeerID: ([^\s]*)' | ForEach-Object { $_.Matches.Groups[1].Value }
+
+# Update the values in ./common/src/warp_runner/mod.rs and store in a temporary file
+(Get-Content .\common\src\warp_runner\mod.rs) -replace '/ip4/104.236.194.35/tcp/34053/', '/ip4/127.0.0.1/tcp/4444/' `
+                                                      -replace 'p2p/12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu', 'p2p/' + $localPeerId ` |
+    Set-Content -Path .\common\src\warp_runner\mod.rs
+
+
+

--- a/scripts/replace_node.sh
+++ b/scripts/replace_node.sh
@@ -3,8 +3,8 @@
 # Read the values from ./warp/peerID
 local_peer_id=$(grep -o 'Local PeerID: [^[:space:]]*' ./warp/peerID.txt | awk '{print $NF}')
 
-# Update the values in ./Makefile and store in a temporary file
-sed -e "s#cargo build --release -F#SHUTTLE_ADDR_POINT=/ip4/127.0.0.1/tcp/4444/p2p/$local_peer_id cargo build --release -F#" ./Makefile > temp_file
+# Update the values in ./common/src/warp_runner/mod.rs and store in a temporary file
+sed -e "s#/ip4/104.236.194.35/tcp/34053/p2p/12D3KooWJSes8386p2T1sMeZ2DzsNJThKkZWbj4US6uPMpEgBTHu#/ip4/127.0.0.1/tcp/4444/p2p/$local_peer_id#" ./common/src/warp_runner/mod.rs > temp_file
 
-# Replace the original Makefile with the modified content
-mv temp_file ./Makefile
+# Replace the original mod.rs with the modified content
+mv temp_file ./common/src/warp_runner/mod.rs

--- a/tests/helpers/commands.ts
+++ b/tests/helpers/commands.ts
@@ -314,7 +314,7 @@ export async function launchAppMacOS(
   await driver.executeScript("macos: launchApp", [
     {
       bundleId: bundle,
-      arguments: ["--discovery", "disable", "--path", homedir() + relativePath],
+      arguments: ["--path", homedir() + relativePath],
     },
   ]);
 }

--- a/tests/suites/MainTests/01-UplinkTests.suite.ts
+++ b/tests/suites/MainTests/01-UplinkTests.suite.ts
@@ -15,6 +15,7 @@ import settingsAboutTests from "@specs/11-settings-about.spec";
 import settingsLicensesTests from "@specs/12-settings-licenses.spec";
 import settingsDeveloperTests from "@specs/13-settings-developer.spec";
 import importAccountTests from "@specs/16-import-account.spec";
+import offlineRequestsTests from "@specs/17-offline-requests.spec";
 
 describe("MacOS Tests", function () {
   describe("Create Pin and Account Tests", createAccountTests.bind(this));
@@ -42,4 +43,5 @@ describe("MacOS Tests", function () {
   describe("Settings Developer Tests", settingsDeveloperTests.bind(this));
   describe("Friends Screen Tests", friendsTests.bind(this));
   describe("Import Account Tests", importAccountTests.bind(this));
+  describe("Offline Friend Requests Tests", offlineRequestsTests.bind(this));
 });

--- a/tests/suites/MainTests/02-UplinkWindows.suite.ts
+++ b/tests/suites/MainTests/02-UplinkWindows.suite.ts
@@ -41,5 +41,4 @@ describe("MacOS Tests", function () {
   describe("Settings Licenses Tests", settingsLicensesTests.bind(this));
   describe("Settings Developer Tests", settingsDeveloperTests.bind(this));
   describe("Import Account Tests", importAccountTests.bind(this));
-  describe("Offline Requests Tests", offlineRequestsTests.bind(this));
 });

--- a/tests/suites/MainTests/02-UplinkWindows.suite.ts
+++ b/tests/suites/MainTests/02-UplinkWindows.suite.ts
@@ -14,6 +14,7 @@ import settingsAboutTests from "@specs/11-settings-about.spec";
 import settingsLicensesTests from "@specs/12-settings-licenses.spec";
 import settingsDeveloperTests from "@specs/13-settings-developer.spec";
 import importAccountTests from "@specs/16-import-account.spec";
+import offlineRequestsTests from "@specs/17-offline-requests.spec";
 
 describe("MacOS Tests", function () {
   describe("Create Pin and Account Tests", createAccountTests.bind(this));
@@ -40,4 +41,5 @@ describe("MacOS Tests", function () {
   describe("Settings Licenses Tests", settingsLicensesTests.bind(this));
   describe("Settings Developer Tests", settingsDeveloperTests.bind(this));
   describe("Import Account Tests", importAccountTests.bind(this));
+  describe("Offline Requests Tests", offlineRequestsTests.bind(this));
 });


### PR DESCRIPTION
### What this PR does 📖

- Replace default warp on uplink before compiling, since appium is not able to pass the shuttle address when opening the compiled file
- Remove discovery disable flags from config files and commands to open app
- Add tests for offline friend testing

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
