### PR TITLE
test(update): close manage members modal manually after bug fix

### DIFF
--- a/tests/specs/reusable-accounts/10-group-chats-edit.spec.ts
+++ b/tests/specs/reusable-accounts/10-group-chats-edit.spec.ts
@@ -122,8 +122,8 @@ export default async function groupChatEditTests() {
     await manageMembers.typeOnSearchUserInput("ChatUserB");
     await manageMembers.clickOnFirstRemoveButton();
 
-    //await manageMembers.validateNothingHereIsDisplayed();
-    //await chatsTopbar.exitManageMembers();
+    await manageMembers.validateNothingHereIsDisplayed();
+    await chatsTopbar.exitManageMembers();
 
     await chatsSidebar.validateNoModalIsOpen();
     await chatsTopbar.validateTopbarExists();
@@ -161,9 +161,8 @@ export default async function groupChatEditTests() {
     await manageMembers.typeOnSearchUserInput("ChatUserB");
     await manageMembers.clickOnFirstAddButton();
 
-    //await manageMembers.validateNothingHereIsDisplayed();
-
-    //await chatsTopbar.exitManageMembers();
+    await manageMembers.validateNothingHereIsDisplayed();
+    await chatsTopbar.exitManageMembers();
 
     await chatsSidebar.validateNoModalIsOpen();
     await chatsTopbar.validateTopbarExists();

--- a/tests/specs/reusable-accounts/11-group-chats-sidebar.spec.ts
+++ b/tests/specs/reusable-accounts/11-group-chats-sidebar.spec.ts
@@ -150,10 +150,10 @@ export default async function groupChatSidebarTests() {
     await manageMembers.typeOnSearchUserInput("ChatUserB");
     await manageMembers.clickOnFirstAddButton();
 
-    //await manageMembers.validateNothingHereIsDisplayed();
+    await manageMembers.validateNothingHereIsDisplayed();
 
     // Close Manage Members and validate topbar contents has correct number of participants
-    // await chatsTopbar.exitManageMembers();
+    await chatsTopbar.exitManageMembers();
 
     await chatsSidebar.validateNoModalIsOpen();
     await chatsTopbar.validateTopbarExists();


### PR DESCRIPTION
### What this PR does 📖

- Exit manage members manually on tests, since bug for manage being closed after adding/removing users from group is now fixed on Uplink

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
