### PR TITLE
test(update): skip friends tests with reusable accounts for now

### DIFF
--- a/tests/suites/MainTests/01-UplinkTests.suite.ts
+++ b/tests/suites/MainTests/01-UplinkTests.suite.ts
@@ -2,7 +2,6 @@ require("module-alias/register");
 import createAccountTests from "@specs/01-create-account.spec";
 import chatsTests from "@specs/02-chats.spec";
 import filesTests from "@specs/03-files.spec";
-import friendsTests from "@specs/04-friends.spec";
 import settingsProfileTests from "@specs/05-settings-profile.spec";
 import settingsGeneralTests from "@specs/06-settings-general.spec";
 import settingsMessagesTests from "@specs/15-settings-messages.spec";
@@ -41,7 +40,6 @@ describe("MacOS Tests", function () {
   describe("Settings About Tests", settingsAboutTests.bind(this));
   describe("Settings Licenses Tests", settingsLicensesTests.bind(this));
   describe("Settings Developer Tests", settingsDeveloperTests.bind(this));
-  describe("Friends Screen Tests", friendsTests.bind(this));
   describe("Import Account Tests", importAccountTests.bind(this));
   describe("Offline Friend Requests Tests", offlineRequestsTests.bind(this));
 });


### PR DESCRIPTION
### What this PR does 📖

- Skipping friends tests with reusable accounts for now, since this will require new test accounts created to run, once that new warp account breaking changes is merged

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
