### PR TITLE
screenobject(update): minor fixes for flaky macos tests

### DIFF
--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Satellite-im/Uplink
+          ref: luis/aria-update
 
       - name: Checkout testing directory 🔖
         uses: actions/checkout@v4
@@ -145,6 +146,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: Satellite-im/Uplink
+          ref: luis/aria-update
 
       - name: Checkout testing directory 🔖
         uses: actions/checkout@v4

--- a/tests/screenobjects/account-creation/CreatePinScreen.ts
+++ b/tests/screenobjects/account-creation/CreatePinScreen.ts
@@ -102,12 +102,16 @@ class CreatePinScreen extends UplinkMainScreen {
     const pinInput = await this.pinInput;
     await pinInput.clearValue();
     await pinInput.setValue(pin);
-
-    const pinToEnterLength = pin.length;
-    const expectedMaskedPin = "•".repeat(pinToEnterLength);
-    const maskedPin = await pinInput.getText();
-    if (maskedPin !== expectedMaskedPin) {
-      await this.enterPinOnCreateAccount(pin);
+    await browser.pause(1000);
+    if (pinInput) {
+      const pinToEnterLength = pin.length;
+      const expectedMaskedPin = "•".repeat(pinToEnterLength);
+      const maskedPin = await pinInput.getText();
+      if (maskedPin !== expectedMaskedPin) {
+        await this.enterPinOnCreateAccount(pin);
+      }
+    } else {
+      return;
     }
   }
 

--- a/tests/screenobjects/account-creation/CreatePinScreen.ts
+++ b/tests/screenobjects/account-creation/CreatePinScreen.ts
@@ -98,9 +98,17 @@ class CreatePinScreen extends UplinkMainScreen {
   }
 
   async enterPinOnLogin(pin: string) {
+    await this.pinInput.waitForExist();
     const pinInput = await this.pinInput;
-    await pinInput.click();
+    await pinInput.clearValue();
     await pinInput.setValue(pin);
+
+    const pinToEnterLength = pin.length;
+    const expectedMaskedPin = "•".repeat(pinToEnterLength);
+    const maskedPin = await pinInput.getText();
+    if (maskedPin !== expectedMaskedPin) {
+      await this.enterPinOnCreateAccount(pin);
+    }
   }
 
   async enterPinOnCreateAccount(pin: string) {

--- a/tests/screenobjects/settings/SettingsAccessibilityScreen.ts
+++ b/tests/screenobjects/settings/SettingsAccessibilityScreen.ts
@@ -15,7 +15,7 @@ const SELECTORS_WINDOWS: selectorContainer = {
   SETTINGS_INFO: '[name="settings-info"]',
   SETTINGS_INFO_DESCRIPTION: "<Text>[2]",
   SETTINGS_INFO_HEADER: "//Text[1]/Text",
-  SETTINGS_LAYOUT: '[name="settings-layout"]',
+  SETTINGS_ACCESSIBILITY: '[name="settings-accessibility"]',
   SWITCH_SLIDER: '[name="Switch Slider"]',
 };
 
@@ -27,7 +27,7 @@ const SELECTORS_MACOS: selectorContainer = {
   SETTINGS_INFO_DESCRIPTION:
     "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText",
   SETTINGS_INFO_HEADER: "-ios class chain:**/XCUIElementTypeStaticText[1]",
-  SETTINGS_LAYOUT: "~settings-layout",
+  SETTINGS_ACCESSIBILITY: "~settings-accessibility",
   SWITCH_SLIDER: "~Switch Slider",
 };
 
@@ -37,7 +37,7 @@ process.env.DRIVER === WINDOWS_DRIVER
 
 class SettingsAccessibilityScreen extends SettingsBaseScreen {
   constructor() {
-    super(SELECTORS.SETTINGS_LAYOUT);
+    super(SELECTORS.SETTINGS_ACCESSIBILITY);
   }
 
   public get openDyslexicCheckbox() {
@@ -65,11 +65,11 @@ class SettingsAccessibilityScreen extends SettingsBaseScreen {
   }
 
   public get openDyslexicSection() {
-    return this.settingsLayout.$(SELECTORS.OPEN_DYSLEXIC_SECTION);
+    return this.settingsAccessibility.$(SELECTORS.OPEN_DYSLEXIC_SECTION);
   }
 
-  public get settingsLayout() {
-    return $(SELECTORS.SETTINGS_LAYOUT);
+  public get settingsAccessibility() {
+    return $(SELECTORS.SETTINGS_ACCESSIBILITY);
   }
 
   async clickOnOpenDyslexic() {

--- a/tests/screenobjects/settings/SettingsAccessibilityScreen.ts
+++ b/tests/screenobjects/settings/SettingsAccessibilityScreen.ts
@@ -15,6 +15,7 @@ const SELECTORS_WINDOWS: selectorContainer = {
   SETTINGS_INFO: '[name="settings-info"]',
   SETTINGS_INFO_DESCRIPTION: "<Text>[2]",
   SETTINGS_INFO_HEADER: "//Text[1]/Text",
+  SETTINGS_LAYOUT: '[name="settings-layout"]',
   SWITCH_SLIDER: '[name="Switch Slider"]',
 };
 
@@ -26,6 +27,7 @@ const SELECTORS_MACOS: selectorContainer = {
   SETTINGS_INFO_DESCRIPTION:
     "-ios class chain:**/XCUIElementTypeGroup/XCUIElementTypeStaticText",
   SETTINGS_INFO_HEADER: "-ios class chain:**/XCUIElementTypeStaticText[1]",
+  SETTINGS_LAYOUT: "~settings-layout",
   SWITCH_SLIDER: "~Switch Slider",
 };
 
@@ -35,7 +37,7 @@ process.env.DRIVER === WINDOWS_DRIVER
 
 class SettingsAccessibilityScreen extends SettingsBaseScreen {
   constructor() {
-    super(SELECTORS.OPEN_DYSLEXIC_SECTION);
+    super(SELECTORS.SETTINGS_LAYOUT);
   }
 
   public get openDyslexicCheckbox() {
@@ -63,7 +65,11 @@ class SettingsAccessibilityScreen extends SettingsBaseScreen {
   }
 
   public get openDyslexicSection() {
-    return $(SELECTORS.OPEN_DYSLEXIC_SECTION);
+    return this.settingsLayout.$(SELECTORS.OPEN_DYSLEXIC_SECTION);
+  }
+
+  public get settingsLayout() {
+    return $(SELECTORS.SETTINGS_LAYOUT);
   }
 
   async clickOnOpenDyslexic() {


### PR DESCRIPTION
### What this PR does 📖

- Minor fix for screenobject on Accessiblity Settings since appium was opening Settings Open Dyslexic section from MacOS instead of Uplink on macos tests
- Minor fix for screenobject on Create Pin Screen to retry entering pin on login when pin entered is not matching with value passed to function

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
