### PR TITLE
chore(appium): save shuttle log on import account windows

### DIFF
--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -306,7 +306,7 @@ jobs:
 
       - name: Launch CI instance of Warp 🚀
         working-directory: ./warp
-        run: ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 > ./shuttle.log
+        run: RUST_LOG=shuttle ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 > ./shuttle.log
 
       - name: Run Tests on MacOS 🧪
         run: npm run mac.ci
@@ -453,7 +453,7 @@ jobs:
 
       - name: Launch CI instance of Warp 🚀
         working-directory: ./warp
-        run: ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 > ./shuttle.log
+        run: RUST_LOG=shuttle ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 > ./shuttle.log
 
       - name: Run Tests on MacOS 🧪
         run: npm run mac.multiremote
@@ -605,7 +605,9 @@ jobs:
 
       - name: Launch CI instance of Warp 🚀
         working-directory: ./warp
-        run: ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 > ./shuttle.log
+        run: |
+          $env:RUST_LOG="shuttle"
+          ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 > ./shuttle.log
 
       - name: Delete Cache Folder if exists - Windows
         run: If (Test-Path $home/.uplink/.user) {Remove-Item -Recurse -Force $home/.uplink/.user} Else { Break }

--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -306,7 +306,8 @@ jobs:
 
       - name: Launch CI instance of Warp 🚀
         working-directory: ./warp
-        run: RUST_LOG=shuttle ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 > ./shuttle.log
+        run: |
+          nohup sh -c "RUST_LOG=shuttle ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 > ./shuttle.log 2>&1 &"
 
       - name: Run Tests on MacOS 🧪
         run: npm run mac.ci
@@ -453,7 +454,8 @@ jobs:
 
       - name: Launch CI instance of Warp 🚀
         working-directory: ./warp
-        run: RUST_LOG=shuttle ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 > ./shuttle.log
+        run: |
+          nohup sh -c "RUST_LOG=shuttle ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 > ./shuttle.log 2>&1 &"
 
       - name: Run Tests on MacOS 🧪
         run: npm run mac.multiremote
@@ -607,7 +609,7 @@ jobs:
         working-directory: ./warp
         run: |
           $env:RUST_LOG="shuttle"
-          ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 > ./shuttle.log
+          Start-Process -FilePath "./target/release/shuttle" -ArgumentList "--keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444" -NoNewWindow -RedirectStandardOutput ./shuttle.log -RedirectStandardError ./shuttle.log
 
       - name: Delete Cache Folder if exists - Windows
         run: If (Test-Path $home/.uplink/.user) {Remove-Item -Recurse -Force $home/.uplink/.user} Else { Break }

--- a/.github/workflows/ui-automated-tests.yml
+++ b/.github/workflows/ui-automated-tests.yml
@@ -306,7 +306,7 @@ jobs:
 
       - name: Launch CI instance of Warp 🚀
         working-directory: ./warp
-        run: ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 &
+        run: ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 > ./shuttle.log
 
       - name: Run Tests on MacOS 🧪
         run: npm run mac.ci
@@ -338,6 +338,13 @@ jobs:
         with:
           name: appium-log-macos
           path: ./appium.log
+
+      - name: Upload Shuttle Log for MacOS 📷
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: shuttle-log-macos
+          path: ./warp/shuttle.log
 
       - name: Add label if any of test jobs failed
         if: failure()
@@ -446,7 +453,7 @@ jobs:
 
       - name: Launch CI instance of Warp 🚀
         working-directory: ./warp
-        run: ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 &
+        run: ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 > ./shuttle.log
 
       - name: Run Tests on MacOS 🧪
         run: npm run mac.multiremote
@@ -488,6 +495,13 @@ jobs:
             ~/.uplink/.user/debug.log
             ~/.uplinkUserB/.user/debug.log
             ~/.uplinkUserC/.user/debug.log
+
+      - name: Upload Shuttle Log for MacOS Chats 📷
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: shuttle-log-macos-chats
+          path: ./warp/shuttle.log
 
       - name: Add label if any of test jobs failed
         if: failure()
@@ -591,7 +605,7 @@ jobs:
 
       - name: Launch CI instance of Warp 🚀
         working-directory: ./warp
-        run: ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 &
+        run: ./target/release/shuttle --keyfile key.bin --listen-addr /ip4/127.0.0.1/tcp/4444 > ./shuttle.log
 
       - name: Delete Cache Folder if exists - Windows
         run: If (Test-Path $home/.uplink/.user) {Remove-Item -Recurse -Force $home/.uplink/.user} Else { Break }
@@ -630,6 +644,13 @@ jobs:
         with:
           name: appium-log-windows
           path: ./appium.log
+
+      - name: Upload Shuttle Log for Windows Chats 📷
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: shuttle-log-windows
+          path: ./warp/shuttle.log
 
       - name: Add label if any of test jobs failed
         if: failure()
@@ -766,6 +787,9 @@ jobs:
             keyfile
             Uplink-windows-latest
             Uplink-macos-latest
+            shuttle-log-macos
+            shuttle-log-macos-chats
+            shuttle-log-windows
             test-report-macos-ci
             test-report-macos-chats
             test-report-windows-ci

--- a/tests/suites/MainTests/02-UplinkWindows.suite.ts
+++ b/tests/suites/MainTests/02-UplinkWindows.suite.ts
@@ -13,9 +13,11 @@ import settingsAccessibilityTests from "@specs/10-settings-accessibility.spec";
 import settingsAboutTests from "@specs/11-settings-about.spec";
 import settingsLicensesTests from "@specs/12-settings-licenses.spec";
 import settingsDeveloperTests from "@specs/13-settings-developer.spec";
+import importAccountTests from "@specs/16-import-account.spec";
 
 describe("Windows Tests", function () {
   describe("Create Pin and Account Tests", createAccountTests.bind(this));
+  describe("Import Account Tests", importAccountTests.bind(this));
   describe("Chats Main Screen Tests", chatsTests.bind(this));
   describe("Files Screen Tests", filesTests.bind(this));
   describe("Settings Profile Tests", settingsProfileTests.bind(this));


### PR DESCRIPTION
<!--  Thanks for sending a pull request!-->

### What this PR does 📖

- Failed Warp Shuttle logs as artifacts if tests failed
- Attempt to execute import account on Windows tests - if test fails, the warp shuttle log should be uploaded as artifact on this pr

### Which issue(s) this PR fixes 🔨

- Resolve #

<!--Add the ticket Github number such as #Resolve #001 to automatically link the PR to the issue-->

### Special notes for reviewers 🗒️

### Additional comments 🎤
